### PR TITLE
Fix yapf workflow caching

### DIFF
--- a/.github/workflows/predicators.yml
+++ b/.github/workflows/predicators.yml
@@ -14,8 +14,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: '**/setup.py'
     - run: |
         pip install -e .
         pip install pytest-cov==2.12.1
@@ -35,8 +33,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install -e .
@@ -55,8 +51,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install -e .
@@ -77,8 +71,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install yapf==0.32.0
@@ -101,8 +93,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install isort==5.10.1
@@ -122,8 +112,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: '**/setup.py'
     - name: Install dependencies
       run: |
         pip install docformatter==1.4


### PR DESCRIPTION
## Summary
- remove pip cache from GitHub workflow steps

## Testing
- `./scripts/run_checks.sh` *(fails: yapf: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685802bff2c4832b968b8d8b69dae92c