### PR TITLE
PR 4/10: Reusable skill factory framework

### DIFF
--- a/predicators/ground_truth_models/skill_factories/__init__.py
+++ b/predicators/ground_truth_models/skill_factories/__init__.py
@@ -1,0 +1,109 @@
+"""Reusable parameterized skill factories for PyBullet environments.
+
+This package provides factory functions that build ``ParameterizedOption``
+instances for common robot manipulation primitives.  Each factory encapsulates
+the multi-phase motion logic (move, grasp, release, etc.) and delegates
+environment-specific target computation to a caller-supplied callback.
+
+Available factories
+-------------------
+- ``create_pick_skill``   -- Pick up an object.
+- ``create_place_skill``  -- Place a held object.
+- ``create_push_skill``   -- Push through waypoints.
+- ``create_pour_skill``   -- Pour from a held container.
+- ``create_move_to_skill``-- Move EE to a target pose.
+- ``create_wait_option``  -- Hold current pose (no-op).
+
+Shared signature pattern
+------------------------
+Most factory functions share the same first three arguments::
+
+    create_<X>_skill(
+        name: str,            # Option name for logging/matching
+        types: Sequence[Type],# Object types (robot first)
+        config: SkillConfig,  # Shared environment configuration
+        ...                   # Skill-specific arguments
+    )
+
+Each factory builds its ``params_space`` internally from canonical parameter
+definitions (e.g. ``_PICK_PARAMS``, ``_PLACE_PARAMS``).  The exception is
+``create_move_to_skill``, which takes an explicit ``params_space`` argument.
+
+``create_place_skill`` uses ``(name, types, config, use_move_above=False)``
+-- target position comes entirely from continuous params, so no callback is
+needed.  ``create_wait_option`` uses ``(name, config, robot_type)`` since it
+always operates on a single robot type with no parameters.
+
+Callback convention
+-------------------
+Every factory (except ``create_place_skill`` and ``create_wait_option``)
+takes a ``get_target_pose_fn`` callback (typed as ``TargetPoseFn``) with
+the uniform signature::
+
+    def get_target_pose_fn(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        config: SkillConfig,
+    ) -> Tuple[float, float, float, float]:
+        '''Return (x, y, z, yaw) for the skill target.'''
+
+Building blocks for custom skills
+----------------------------------
+- ``make_move_to_phase`` -- Create a single MOVE_TO_POSE phase for use
+  in custom ``PhaseSkill`` compositions.
+- ``Phase``, ``PhaseAction``, ``PhaseSkill`` -- Low-level primitives for
+  building skills with non-standard phase sequences.
+
+Quick start example::
+
+    from predicators.ground_truth_models.skill_factories import (
+        SkillConfig, create_pick_skill, create_place_skill, create_wait_option,
+    )
+
+    config = SkillConfig(
+        robot=pybullet_robot,
+        open_fingers_joint=pybullet_robot.open_fingers,
+        closed_fingers_joint=pybullet_robot.closed_fingers,
+        fingers_state_to_joint=MyEnv._fingers_state_to_joint,
+    )
+
+    def _get_obj_pose(state, objects, params, config):
+        _, obj = objects
+        return (state.get(obj, "x"), state.get(obj, "y"),
+                state.get(obj, "z"), 0.0)
+
+    Pick = create_pick_skill("Pick", [robot_type, obj_type],
+                             config, _get_obj_pose)
+"""
+
+from predicators.ground_truth_models.skill_factories.base import Phase, \
+    PhaseAction, PhaseSkill, SkillConfig, TargetPoseFn, build_params_space
+from predicators.ground_truth_models.skill_factories.move_to import \
+    create_move_to_skill, make_move_to_phase
+from predicators.ground_truth_models.skill_factories.pick import \
+    create_pick_skill
+from predicators.ground_truth_models.skill_factories.place import \
+    create_place_skill
+from predicators.ground_truth_models.skill_factories.pour import \
+    create_pour_skill
+from predicators.ground_truth_models.skill_factories.push import \
+    create_push_skill
+from predicators.ground_truth_models.skill_factories.wait import \
+    create_wait_option
+
+__all__ = [
+    "Phase",
+    "PhaseAction",
+    "PhaseSkill",
+    "SkillConfig",
+    "TargetPoseFn",
+    "build_params_space",
+    "create_move_to_skill",
+    "make_move_to_phase",
+    "create_pick_skill",
+    "create_place_skill",
+    "create_pour_skill",
+    "create_push_skill",
+    "create_wait_option",
+]

--- a/predicators/ground_truth_models/skill_factories/base.py
+++ b/predicators/ground_truth_models/skill_factories/base.py
@@ -1,0 +1,703 @@
+"""Core abstractions for reusable parameterized skills."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, \
+    Sequence, Tuple, cast
+
+if TYPE_CHECKING:
+    from predicators.envs.pybullet_env import PyBulletEnv
+
+import numpy as np
+import pybullet as p
+from gym.spaces import Box
+
+from predicators import utils
+from predicators.pybullet_helpers.controllers import \
+    get_change_fingers_action, get_move_end_effector_to_pose_action
+from predicators.pybullet_helpers.geometry import Pose
+from predicators.pybullet_helpers.inverse_kinematics import \
+    InverseKinematicsError
+from predicators.pybullet_helpers.joint import JointPositions
+from predicators.pybullet_helpers.motion_planning import run_motion_planning
+from predicators.pybullet_helpers.robots.single_arm import \
+    SingleArmPyBulletRobot
+from predicators.settings import CFG
+from predicators.structs import Action, Array, Object, ParameterizedOption, \
+    State, Type
+
+
+class PhaseAction(Enum):
+    """The type of action a phase executes."""
+    MOVE_TO_POSE = auto()
+    CHANGE_FINGERS = auto()
+
+
+@dataclass(frozen=True)
+class SkillConfig:
+    """Configuration shared across all skill factories for one environment.
+
+    Every skill factory function (``create_pick_skill``, ``create_place_skill``,
+    etc.) takes a ``SkillConfig`` as its fourth argument.  Each environment
+    options file creates one ``SkillConfig`` and passes it to all its skill
+    factory calls.
+
+    Example::
+
+        config = SkillConfig(
+            robot=pybullet_robot,
+            open_fingers_joint=pybullet_robot.open_fingers,
+            closed_fingers_joint=pybullet_robot.closed_fingers,
+            fingers_state_to_joint=MyEnv._fingers_state_to_joint,
+            robot_init_tilt=MyEnv.robot_init_tilt,   # default 0.0
+            robot_init_wrist=MyEnv.robot_init_wrist,  # default 0.0
+        )
+
+    Attributes:
+        robot: The PyBullet robot instance.
+        open_fingers_joint: Joint value for fully open fingers.
+        closed_fingers_joint: Joint value for fully closed fingers.
+        fingers_state_to_joint: Callable that maps the finger *state feature*
+            value to the corresponding joint value.  Signature:
+            ``(robot, finger_state_value) -> joint_value``.  Typically
+            ``MyEnv._fingers_state_to_joint``.
+        collision_bodies: PyBullet body IDs to treat as obstacles during
+            BiRRT planning.  Defaults to empty (no collision checking).
+        move_to_pose_tol: Squared-distance tolerance for move-to-pose
+            terminal (used when BiRRT falls back to incremental IK).
+        finger_action_nudge_magnitude: Nudge magnitude for finger drift
+            resistance in the wait option and during move phases.
+        max_vel_norm: Maximum velocity norm for incremental IK EE movement.
+        grasp_tol: Squared-distance tolerance for CHANGE_FINGERS terminal.
+        ik_validate: Whether to validate IK solutions.
+        robot_init_tilt: Default EE tilt (pitch) angle — the second Euler
+            angle in ``[roll=0, pitch, yaw]``.
+        robot_init_wrist: Default EE wrist (yaw) angle — the third Euler
+            angle.  Usually 0.0 or ``-pi``.
+        robot_home_pos: ``(x, y, z)`` home position the robot retreats to
+            after push skills.  Required by ``create_push_skill``.
+        transport_z: Safe Z height for transit above obstacles during
+            pick, place, push, and pour skills.  Default ``0.7``.
+        extra: Arbitrary dict for environment-specific constants that
+            callbacks may need.  Access via ``config.extra["key"]``.
+    """
+    robot: SingleArmPyBulletRobot
+    open_fingers_joint: float
+    closed_fingers_joint: float
+    fingers_state_to_joint: Callable[[SingleArmPyBulletRobot, float], float]
+    collision_bodies: Tuple[int, ...] = ()
+    move_to_pose_tol: float = 1e-4
+    finger_action_nudge_magnitude: float = 1e-3
+    max_vel_norm: float = 0.05
+    grasp_tol: float = 5e-4
+    ik_validate: bool = True
+    robot_init_tilt: float = 0.0
+    robot_init_wrist: float = 0.0
+    robot_home_pos: Optional[Tuple[float, float, float]] = None
+    transport_z: float = 0.7
+    simulator: Optional[PyBulletEnv] = None
+    collision_skip_types: Tuple[str, ...] = ()
+    sim_extra_collision_bodies: Tuple[int, ...] = ()
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+
+def build_params_space(
+    param_defs: Sequence[Tuple[str, float, float]],
+) -> Tuple[Box, Tuple[str, ...]]:
+    """Build a params_space and description from ``(name, low, high)`` tuples.
+
+    Returns:
+        ``(params_space, params_description)``
+    """
+    names = tuple(name for name, _, _ in param_defs)
+    low = np.array([lo for _, lo, _ in param_defs], dtype=np.float64)
+    high = np.array([hi for _, _, hi in param_defs], dtype=np.float64)
+    return Box(low=low, high=high, dtype=np.float64), names
+
+
+# ---------------------------------------------------------------------------
+# Public type aliases
+# ---------------------------------------------------------------------------
+
+# Callback signature shared by ALL skill factory ``get_target_pose_fn`` args.
+# (state, objects, params, config) -> (x, y, z, yaw)
+TargetPoseFn = Callable[[State, Sequence[Object], Array, SkillConfig],
+                        Tuple[float, float, float, float]]
+
+# ---------------------------------------------------------------------------
+# Internal type aliases for Phase target functions
+# ---------------------------------------------------------------------------
+
+# For MOVE_TO_POSE: returns (current_pose, target_pose, finger_status)
+MoveToPoseTargetFn = Callable[[State, Sequence[Object], Array, SkillConfig],
+                              Tuple[Pose, Pose, str]]
+
+# For CHANGE_FINGERS: returns (current_val, target_val)
+ChangeFingersTargetFn = Callable[[State, Sequence[Object], Array, SkillConfig],
+                                 Tuple[float, float]]
+
+# Memory keys used per phase, keyed by phase object id.
+_BIRRT_TRAJ_KEY = "birrt_traj_{}"  # stores List[JointPositions] or None
+_BIRRT_STEP_KEY = "birrt_step_{}"  # stores int index into trajectory
+_BIRRT_FINGER_KEY = "birrt_finger_{}"  # stores finger_status str
+
+
+@dataclass
+class Phase:
+    """A single phase in a multi-phase skill.
+
+    Attributes:
+        name: Human-readable phase name (for logging).
+        action_type: Whether this phase moves the EE or changes fingers.
+        target_fn: Callable that computes targets from state/objects/params.
+            For MOVE_TO_POSE: returns (current_pose, target_pose, finger_status)
+            For CHANGE_FINGERS: returns (current_val, target_val)
+        terminal_fn: Optional custom terminal condition override.
+            Signature: (state, objects, params, config) -> bool
+        finger_tol: Tolerance for CHANGE_FINGERS terminal (defaults to
+            config.grasp_tol if None).
+        use_motion_planning: If True (default) and action_type is
+            MOVE_TO_POSE, use BiRRT to plan a joint-space trajectory on the
+            first call and cache it; subsequent calls pop waypoints from the
+            cached plan. Falls back to incremental IK if planning fails.
+            If False, always use incremental IK stepping.
+    """
+    name: str
+    action_type: PhaseAction
+    # Union[MoveToPoseTargetFn, ChangeFingersTargetFn]; typed as Any to
+    # avoid Pylance issues when unpacking return tuples after runtime
+    # dispatch on action_type.
+    target_fn: Any
+    terminal_fn: Optional[Callable[
+        [State, Sequence[Object], Array, SkillConfig], bool]] = None
+    finger_tol: Optional[float] = None
+    use_motion_planning: bool = field(
+        default_factory=lambda: CFG.skill_phase_use_motion_planning)
+
+
+class PhaseSkill:
+    """A multi-phase controller that builds a ParameterizedOption.
+
+    Each phase is executed sequentially. The skill advances to the next
+    phase when the current phase's terminal condition is met. The overall
+    skill terminates when the last phase is terminal.
+
+    For MOVE_TO_POSE phases with use_motion_planning=True (the default),
+    BiRRT plans a collision-free joint-space trajectory on the first call
+    and caches it in the option memory dict. Subsequent calls pop waypoints
+    from the cached plan one at a time. If BiRRT fails, the phase falls back
+    to incremental IK delta-stepping.
+
+    Usage:
+        option = PhaseSkill("Pick", types, params_space, config, phases).build()
+    """
+
+    def __init__(self,
+                 name: str,
+                 types: Sequence[Type],
+                 params_space: Box,
+                 config: SkillConfig,
+                 phases: List[Phase],
+                 params_description: Optional[Tuple[str, ...]] = None) -> None:
+        assert len(phases) > 0
+        self._name = name
+        self._types = types
+        self._params_space = params_space
+        self._config = config
+        self._phases = phases
+        self._params_description = params_description
+
+    def build(self) -> ParameterizedOption:
+        """Build and return the ParameterizedOption."""
+        return ParameterizedOption(
+            self._name,
+            types=self._types,
+            params_space=self._params_space,
+            policy=self._policy,
+            initiable=self._initiable,
+            terminal=self._terminal,
+            params_description=self._params_description,
+        )
+
+    def _initiable(self, state: State, memory: Dict, objects: Sequence[Object],
+                   params: Array) -> bool:
+        del state, objects, params  # unused
+        memory["phase_idx"] = 0
+        return True
+
+    def _policy(self, state: State, memory: Dict, objects: Sequence[Object],
+                params: Array) -> Action:
+        phase_idx = memory["phase_idx"]
+        phase = self._phases[phase_idx]
+
+        # Check if current phase is terminal → advance.
+        if self._phase_is_terminal(phase, state, memory, objects, params):
+            phase_idx += 1
+            memory["phase_idx"] = phase_idx
+            if phase_idx >= len(self._phases):
+                # Should not be called after overall terminal, but guard.
+                phase_idx = len(self._phases) - 1
+                memory["phase_idx"] = phase_idx
+            phase = self._phases[phase_idx]
+            logging.debug(f"[{self._name}] Advanced to phase {phase_idx}: "
+                          f"{phase.name}")
+
+        if phase.action_type == PhaseAction.MOVE_TO_POSE:
+            return self._execute_move(phase, state, memory, objects, params)
+        assert phase.action_type == PhaseAction.CHANGE_FINGERS
+        return self._execute_fingers(phase, state, objects, params)
+
+    def _terminal(self, state: State, memory: Dict, objects: Sequence[Object],
+                  params: Array) -> bool:
+        phase_idx = memory["phase_idx"]
+        if phase_idx < len(self._phases) - 1:
+            return False
+        phase = self._phases[phase_idx]
+        return self._phase_is_terminal(phase, state, memory, objects, params)
+
+    # ------------------------------------------------------------------
+    # Phase terminal conditions
+    # ------------------------------------------------------------------
+
+    def _phase_is_terminal(self, phase: Phase, state: State, memory: Dict,
+                           objects: Sequence[Object], params: Array) -> bool:
+        """Check if a phase has reached its terminal condition."""
+        # Custom terminal override takes priority.
+        if phase.terminal_fn is not None:
+            return phase.terminal_fn(state, objects, params, self._config)
+
+        if phase.action_type == PhaseAction.CHANGE_FINGERS:
+            current_val, target_val = phase.target_fn(state, objects, params,
+                                                      self._config)
+            tol = phase.finger_tol if phase.finger_tol is not None \
+                else self._config.grasp_tol
+            return bool((target_val - current_val)**2 < tol)
+
+        # MOVE_TO_POSE
+        if phase.use_motion_planning:
+            return self._birrt_phase_is_terminal(phase, state, memory, objects,
+                                                 params)
+        return self._ik_phase_is_terminal(phase, state, objects, params)
+
+    def _birrt_phase_is_terminal(self, phase: Phase, state: State,
+                                 memory: Dict, objects: Sequence[Object],
+                                 params: Array) -> bool:
+        """Terminal for a BiRRT-planned phase.
+
+        Returns True when the cached trajectory is fully consumed, or
+        when the fallback IK terminal is satisfied (BiRRT planning
+        failed). Returns False if the trajectory hasn't been computed
+        yet (first call).
+        """
+        pid = id(phase)
+        traj_key = _BIRRT_TRAJ_KEY.format(pid)
+        step_key = _BIRRT_STEP_KEY.format(pid)
+
+        if traj_key not in memory:
+            # Trajectory not yet computed — not terminal.
+            return False
+
+        traj = memory[traj_key]
+        if traj is None:
+            # BiRRT failed; use distance-based terminal (IK fallback mode).
+            return self._ik_phase_is_terminal(phase, state, objects, params)
+
+        # All waypoints consumed — fall back to position-based terminal so
+        # the phase doesn't end until the robot has actually converged to the
+        # target (position control may lag behind the commanded trajectory,
+        # and IK inaccuracy means the final waypoint may not exactly match
+        # the target Cartesian pose).
+        if memory[step_key] >= len(traj):
+            return self._ik_phase_is_terminal(phase, state, objects, params)
+        return False
+
+    def _ik_phase_is_terminal(self, phase: Phase, state: State,
+                              objects: Sequence[Object],
+                              params: Array) -> bool:
+        """Distance-based terminal for incremental IK phases."""
+        current_pose, target_pose, _ = phase.target_fn(state, objects, params,
+                                                       self._config)
+        squared_dist = np.sum(
+            np.square(np.subtract(current_pose.position,
+                                  target_pose.position)))
+        return bool(squared_dist < self._config.move_to_pose_tol)
+
+    # ------------------------------------------------------------------
+    # Phase execution
+    # ------------------------------------------------------------------
+
+    def _execute_move(self, phase: Phase, state: State, memory: Dict,
+                      objects: Sequence[Object], params: Array) -> Action:
+        """Dispatch to BiRRT or incremental IK based on phase flag."""
+        if phase.use_motion_planning:
+            return self._execute_move_birrt(phase, state, memory, objects,
+                                            params)
+        return self._execute_move_ik(phase, state, objects, params)
+
+    def _execute_move_birrt(self, phase: Phase, state: State, memory: Dict,
+                            objects: Sequence[Object],
+                            params: Array) -> Action:
+        """Execute a MOVE_TO_POSE phase using BiRRT with lazy plan caching.
+
+        On the first call for this phase:
+          1. Compute the target joint positions via IK.
+          2. Run BiRRT from the current joint positions to the target.
+          3. Cache the resulting trajectory (or None on failure).
+          4. Cache the finger_status for nudging during trajectory replay.
+
+        On subsequent calls, pop the next waypoint from the cached trajectory
+        and return the corresponding joint-position action, applying a small
+        finger nudge matching the phase's finger_status (same as incremental
+        IK) to prevent drift and allow finger transitions during movement.
+
+        Falls back to incremental IK if BiRRT planning fails.
+        """
+        pid = id(phase)
+        traj_key = _BIRRT_TRAJ_KEY.format(pid)
+        step_key = _BIRRT_STEP_KEY.format(pid)
+        finger_key = _BIRRT_FINGER_KEY.format(pid)
+
+        pb_state = cast(utils.PyBulletState, state)
+        robot = self._config.robot
+
+        if traj_key not in memory:
+            # --- First call: plan the trajectory. ---
+            _, target_pose, finger_status = phase.target_fn(
+                state, objects, params, self._config)
+            memory[finger_key] = finger_status
+
+            if self._config.simulator is not None:
+                traj = self._plan_with_simulator(pb_state, target_pose,
+                                                 phase.name)
+            else:
+                traj = self._plan_without_simulator(pb_state, target_pose,
+                                                    phase.name)
+
+            if traj is None:
+                logging.warning(f"[{self._name}/{phase.name}] BiRRT failed; "
+                                "falling back to incremental IK.")
+                memory[traj_key] = None
+            else:
+                # Skip the first waypoint — BiRRT includes the start
+                # position (current joints) as traj[0].  Commanding the
+                # robot to stay at its current position is a no-op that
+                # triggers the option-model "option got stuck" check
+                # (option_model_terminate_on_repeat), aborting the option
+                # after a single step.
+                traj_list = list(traj)
+                memory[traj_key] = traj_list[1:] if len(traj_list) > 1 \
+                    else traj_list
+            memory[step_key] = 0
+
+            # Restore robot joints — run_motion_planning leaves them at an
+            # arbitrary configuration used during collision checking.
+            robot.set_joints(pb_state.joint_positions)
+
+        traj = memory[traj_key]
+        if traj is None:
+            # BiRRT failed — fall back to incremental IK.
+            return self._execute_move_ik(phase, state, objects, params)
+
+        # --- Pop next waypoint from cached trajectory. ---
+        step = memory[step_key]
+
+        if step >= len(traj):
+            # Trajectory fully consumed — use incremental IK to converge
+            # to the exact target pose (BiRRT's IK solution may be slightly
+            # off from the target Cartesian pose).
+            return self._execute_move_ik(phase, state, objects, params)
+
+        target_joints = traj[step]
+        memory[step_key] = step + 1
+
+        # Apply finger nudge matching the phase's finger_status, identical
+        # to what incremental IK does in controllers.py.  This prevents
+        # finger drift and allows finger transitions (e.g. open→closed)
+        # to happen gradually during BiRRT trajectory replay.
+        joint_action = list(target_joints)
+        finger_idx_l = robot.left_finger_joint_idx
+        finger_idx_r = robot.right_finger_joint_idx
+        current_fingers = pb_state.joint_positions[finger_idx_l]
+        finger_status = memory[finger_key]
+        if finger_status == "open":
+            finger_delta = self._config.finger_action_nudge_magnitude
+        else:
+            finger_delta = -self._config.finger_action_nudge_magnitude
+        f_action = current_fingers + finger_delta
+        joint_action[finger_idx_l] = f_action
+        joint_action[finger_idx_r] = f_action
+
+        action_arr = np.clip(
+            np.array(joint_action, dtype=np.float32),
+            robot.action_space.low,
+            robot.action_space.high,
+        )
+        return Action(action_arr)
+
+    # ------------------------------------------------------------------
+    # BiRRT planning helpers
+    # ------------------------------------------------------------------
+
+    # Non-physical types that have no PyBullet body and should be skipped
+    # when collecting collision bodies.
+    _SKIP_TYPES = frozenset({
+        "robot",
+        "loc",
+        "angle",
+        "human",
+        "side",
+        "direction",
+    })
+
+    @staticmethod
+    def _collect_sim_objects(sim: PyBulletEnv) -> Dict[str, Object]:
+        """Collect all Objects with body IDs from a PyBulletEnv instance."""
+        obj_map: Dict[str, Object] = {}
+        # Scan instance attributes for Object instances with body IDs.
+        for attr_val in sim.__dict__.values():
+            if isinstance(attr_val, Object) and attr_val.id is not None:
+                obj_map[attr_val.name] = attr_val
+            elif isinstance(attr_val, (list, tuple)):
+                for item in attr_val:
+                    if isinstance(item, Object) and item.id is not None:
+                        obj_map[item.name] = item
+        # Composed envs: also enumerate component objects.
+        for comp in getattr(sim, '_components', []):
+            for obj in comp.get_objects():
+                obj_map[obj.name] = obj
+        # Always include the robot.
+        obj_map[sim._robot.name] = sim._robot
+        return obj_map
+
+    def _plan_without_simulator(
+        self,
+        pb_state: utils.PyBulletState,
+        target_pose: Pose,
+        phase_name: str,
+    ) -> Optional[Sequence[JointPositions]]:
+        """Plan using the config robot's physics client (no collision
+        bodies)."""
+        robot = self._config.robot
+        robot.set_joints(pb_state.joint_positions)
+        try:
+            target_joints: JointPositions = robot.inverse_kinematics(
+                target_pose,
+                validate=self._config.ik_validate,
+                set_joints=True)
+        except InverseKinematicsError:
+            pos = target_pose.position
+            logging.warning(
+                f"[{self._name}/{phase_name}] IK failed for BiRRT target "
+                f"({pos[0]:.3f}, {pos[1]:.3f}, {pos[2]:.3f}); "
+                "falling back to incremental IK.")
+            return None
+
+        return run_motion_planning(
+            robot=robot,
+            initial_positions=pb_state.joint_positions,
+            target_positions=target_joints,
+            collision_bodies=self._config.collision_bodies,
+            seed=CFG.seed,
+            physics_client_id=robot.physics_client_id,
+        )
+
+    def _plan_with_simulator(
+        self,
+        pb_state: utils.PyBulletState,
+        target_pose: Pose,
+        phase_name: str,
+    ) -> Optional[Sequence[JointPositions]]:
+        """Plan using the simulator env for collision-aware motion planning.
+
+        Remaps the current state onto the simulator's objects, resets
+        the simulator, collects collision body IDs, and runs IK + BiRRT
+        on the simulator's physics client.
+        """
+        sim = self._config.simulator
+        assert sim is not None
+
+        # 1. Build name -> simulator Object mapping
+        sim_obj_map = self._collect_sim_objects(sim)
+
+        # 2. Remap state: simulator Objects with original feature values
+        new_state_data: Dict[Object, Any] = {}
+        for orig_obj, features in pb_state.data.items():
+            sim_obj = sim_obj_map.get(orig_obj.name)
+            if sim_obj is not None:
+                new_state_data[sim_obj] = features.copy()
+
+        remapped_state = utils.PyBulletState(
+            new_state_data, simulator_state=pb_state.simulator_state)
+
+        # 3. Reset simulator to current state
+        sim._reset_state(remapped_state)
+
+        # 4. Collect collision body IDs (exclude held objects and
+        #    non-physical types) and find the held object.
+        collision_bodies: set = set()
+        held_object: Optional[int] = None
+        for orig_obj in pb_state:
+            if orig_obj.type.name in self._SKIP_TYPES or \
+                    orig_obj.type.name in self._config.collision_skip_types:
+                continue
+            sim_obj = sim_obj_map.get(orig_obj.name)
+            if sim_obj is None or sim_obj.id is None:
+                continue
+            if "is_held" in orig_obj.type.feature_names and \
+                    pb_state.get(orig_obj, "is_held") > 0.5:
+                held_object = sim_obj.id
+                continue
+            collision_bodies.add(sim_obj.id)
+
+        # 4b. Add tables if present.
+        if hasattr(sim, '_table_ids'):
+            for tid in sim._table_ids:
+                collision_bodies.add(tid)
+        elif hasattr(sim, '_table') and sim._table.id is not None:
+            collision_bodies.add(sim._table.id)
+
+        # 4c. Add extra sim collision bodies (e.g. virtual buffer zones).
+        collision_bodies.update(self._config.sim_extra_collision_bodies)
+
+        # 4d. Add environment-specific extra collision bodies (e.g. liquid
+        #     blocks in Grow that aren't tracked as state Objects).
+        collision_bodies.update(sim.get_extra_collision_ids())
+
+        # 5. IK + motion planning on simulator's robot
+        planning_robot = sim._pybullet_robot
+        planning_robot.set_joints(pb_state.joint_positions)
+        try:
+            target_joints: JointPositions = planning_robot.inverse_kinematics(
+                target_pose,
+                validate=self._config.ik_validate,
+                set_joints=True)
+        except InverseKinematicsError:
+            pos = target_pose.position
+            logging.warning(
+                f"[{self._name}/{phase_name}] IK failed for BiRRT target "
+                f"({pos[0]:.3f}, {pos[1]:.3f}, {pos[2]:.3f}); "
+                "falling back to incremental IK.")
+            return None
+
+        # Compute base_link_to_held_obj if an object is held.
+        base_link_to_held_obj = None
+        if held_object is not None and sim._held_obj_to_base_link is not None:
+            base_link_to_held_obj = p.invertTransform(
+                *sim._held_obj_to_base_link)
+
+        traj = run_motion_planning(
+            robot=planning_robot,
+            initial_positions=pb_state.joint_positions,
+            target_positions=target_joints,
+            collision_bodies=collision_bodies,
+            seed=CFG.seed,
+            physics_client_id=sim._physics_client_id,
+            held_object=held_object,
+            base_link_to_held_obj=base_link_to_held_obj,
+        )
+
+        if traj is None:
+            self._log_collision_diagnostics(planning_robot,
+                                            sim._physics_client_id,
+                                            pb_state.joint_positions,
+                                            target_joints, collision_bodies,
+                                            held_object, base_link_to_held_obj,
+                                            phase_name)
+
+        return traj
+
+    def _log_collision_diagnostics(
+        self,
+        planning_robot: SingleArmPyBulletRobot,
+        physics_client_id: int,
+        start_joints: JointPositions,
+        goal_joints: JointPositions,
+        collision_bodies: set,
+        held_object: Optional[int],
+        base_link_to_held_obj: Optional[Any],
+        phase_name: str,
+    ) -> None:
+        """Log which collision bodies cause start/goal collisions."""
+        from predicators.pybullet_helpers.link import get_link_state
+
+        def _check(joints: JointPositions, label: str) -> None:
+            planning_robot.set_joints(joints)
+            if held_object is not None and base_link_to_held_obj is not None:
+                wt_bl = get_link_state(
+                    planning_robot.robot_id,
+                    planning_robot.end_effector_id,
+                    physics_client_id=physics_client_id).com_pose
+                wt_ho = p.multiplyTransforms(wt_bl[0], wt_bl[1],
+                                             base_link_to_held_obj[0],
+                                             base_link_to_held_obj[1])
+                p.resetBasePositionAndOrientation(
+                    held_object,
+                    wt_ho[0],
+                    wt_ho[1],
+                    physicsClientId=physics_client_id)
+            p.performCollisionDetection(physicsClientId=physics_client_id)
+            for body in collision_bodies:
+                body_name = ""
+                try:
+                    body_name = p.getBodyInfo(
+                        body, physicsClientId=physics_client_id)[1].decode()
+                except Exception:
+                    pass
+                if p.getContactPoints(planning_robot.robot_id,
+                                      body,
+                                      physicsClientId=physics_client_id):
+                    logging.error(f"[{self._name}/{phase_name}] {label} ROBOT "
+                                  f"collision with body {body} ({body_name})")
+                if held_object is not None and p.getContactPoints(
+                        held_object, body, physicsClientId=physics_client_id):
+                    logging.error(f"[{self._name}/{phase_name}] {label} HELD "
+                                  f"collision with body {body} ({body_name})")
+
+        _check(start_joints, "START")
+        _check(goal_joints, "GOAL")
+
+    def _execute_move_ik(self, phase: Phase, state: State,
+                         objects: Sequence[Object], params: Array) -> Action:
+        """Execute a MOVE_TO_POSE phase using incremental IK delta-stepping."""
+        pb_state = cast(utils.PyBulletState, state)
+        robot = self._config.robot
+        robot.set_joints(pb_state.joint_positions)
+        current_pose, target_pose, finger_status = phase.target_fn(
+            state, objects, params, self._config)
+        try:
+            return get_move_end_effector_to_pose_action(
+                robot=robot,
+                current_joint_positions=pb_state.joint_positions,
+                current_pose=current_pose,
+                target_pose=target_pose,
+                finger_status=finger_status,
+                max_vel_norm=self._config.max_vel_norm,
+                finger_action_nudge_magnitude=(
+                    self._config.finger_action_nudge_magnitude),
+                validate=self._config.ik_validate,
+            )
+        except utils.OptionExecutionFailure:
+            cur = current_pose.position
+            tgt = target_pose.position
+            raise utils.OptionExecutionFailure(
+                f"[{self._name}/{phase.name}] IK failed. "
+                f"current=({cur[0]:.3f}, {cur[1]:.3f}, {cur[2]:.3f}), "
+                f"target=({tgt[0]:.3f}, {tgt[1]:.3f}, {tgt[2]:.3f}), "
+                f"params={params.tolist()}")
+
+    def _execute_fingers(self, phase: Phase, state: State,
+                         objects: Sequence[Object], params: Array) -> Action:
+        """Execute a CHANGE_FINGERS phase."""
+        pb_state = cast(utils.PyBulletState, state)
+        current_val, target_val = phase.target_fn(state, objects, params,
+                                                  self._config)
+        return get_change_fingers_action(
+            self._config.robot,
+            pb_state.joint_positions,
+            current_val,
+            target_val,
+            self._config.max_vel_norm,
+        )

--- a/predicators/ground_truth_models/skill_factories/move_to.py
+++ b/predicators/ground_truth_models/skill_factories/move_to.py
@@ -1,0 +1,167 @@
+"""Move-to-pose skill factory and reusable phase builder.
+
+This module provides:
+
+- ``create_move_to_skill`` -- A single-phase skill that moves the EE to
+  a target pose while preserving the current finger state.
+- ``make_move_to_phase`` -- A lower-level helper that creates a single
+  ``Phase`` object for use in custom ``PhaseSkill`` compositions (used
+  internally by ``create_push_skill`` and available for building custom
+  multi-phase skills).
+
+Example::
+
+    from predicators.ground_truth_models.skill_factories import (
+        SkillConfig, create_move_to_skill,
+    )
+
+    def _get_home_pose(state, objects, params, config):
+        return (1.35, 0.75, 0.75, 0.0)
+
+    MoveHome = create_move_to_skill(
+        name="MoveHome",
+        types=[robot_type],
+        params_space=Box(0, 1, (0,)),
+        config=config,
+        get_target_pose_fn=_get_home_pose,
+    )
+"""
+
+from typing import Optional, Sequence, Tuple
+
+import pybullet as p
+from gym.spaces import Box
+
+from predicators.ground_truth_models.skill_factories.base import Phase, \
+    PhaseAction, PhaseSkill, SkillConfig, TargetPoseFn
+from predicators.pybullet_helpers.geometry import Pose
+from predicators.structs import Array, Object, ParameterizedOption, State, Type
+
+
+def create_move_to_skill(
+    name: str,
+    types: Sequence[Type],
+    params_space: Box,
+    config: SkillConfig,
+    get_target_pose_fn: TargetPoseFn,
+    params_description: Optional[Tuple[str, ...]] = None,
+) -> ParameterizedOption:
+    """Create a single-phase move-to-pose skill.
+
+    Preserves the current finger status (open/closed) from state.
+
+    Phases:
+        0. **Move** -- Move end-effector to the target pose, preserving
+           the current finger state.
+
+    Args:
+        name: Option name.
+        types: Ordered object types.  The first element **must** be the
+            robot type.
+        params_space: Continuous parameter space.
+        config: Shared skill configuration.  See ``SkillConfig``.
+        get_target_pose_fn: Callback that returns the target as
+            ``(x, y, z, yaw)`` from ``(state, objects, params, config)``.
+
+    Returns:
+        A ``ParameterizedOption`` implementing the move-to-pose skill.
+    """
+    phase = make_move_to_phase(name, get_target_pose_fn)
+    return PhaseSkill(name,
+                      types,
+                      params_space,
+                      config, [phase],
+                      params_description=params_description).build()
+
+
+def _get_current_ee_pose(state: State, robot_obj: Object) -> Pose:
+    """Extract current end-effector pose from state."""
+    position = (state.get(robot_obj,
+                          "x"), state.get(robot_obj,
+                                          "y"), state.get(robot_obj, "z"))
+    orientation = p.getQuaternionFromEuler(
+        [0, state.get(robot_obj, "tilt"),
+         state.get(robot_obj, "wrist")])
+    return Pose(position, orientation)
+
+
+def _get_finger_status(state: State, robot_obj: Object,
+                       cfg: SkillConfig) -> str:
+    """Infer 'open' or 'closed' from current finger state."""
+    current_fingers = state.get(robot_obj, "fingers")
+    finger_joint = cfg.fingers_state_to_joint(cfg.robot, current_fingers)
+    if abs(finger_joint - cfg.open_fingers_joint) < \
+            abs(finger_joint - cfg.closed_fingers_joint):
+        return "open"
+    return "closed"
+
+
+def make_move_to_phase(
+    name: str,
+    get_target_pose_fn: TargetPoseFn,
+    finger_status: Optional[str] = None,
+) -> Phase:
+    """Create a MOVE_TO_POSE phase for use in a ``PhaseSkill``.
+
+    This is a building block for composing custom multi-phase skills.
+    For example, ``create_push_skill`` uses this internally to create
+    each waypoint phase.
+
+    Args:
+        name: Phase name (for logging).
+        get_target_pose_fn: Callback that returns ``(x, y, z, yaw)``
+            from ``(state, objects, params, config)``.
+        finger_status: ``"open"`` or ``"closed"``.  If ``None``, preserves
+            the current finger status from state.
+
+    Returns:
+        A ``Phase`` that can be included in a ``PhaseSkill``.
+
+    Example::
+
+        from predicators.ground_truth_models.skill_factories import (
+            Phase, PhaseAction, PhaseSkill, SkillConfig, make_move_to_phase,
+        )
+
+        def _above_target(state, objects, params, config):
+            _, obj = objects
+            return (state.get(obj, "x"), state.get(obj, "y"),
+                    0.8, state.get(obj, "yaw"))
+
+        def _at_target(state, objects, params, config):
+            _, obj = objects
+            return (state.get(obj, "x"), state.get(obj, "y"),
+                    state.get(obj, "z"), state.get(obj, "yaw"))
+
+        phases = [
+            make_move_to_phase("MoveAbove", _above_target, "closed"),
+            make_move_to_phase("Descend",   _at_target,    "open"),
+        ]
+        skill = PhaseSkill("Custom", types, params_space, config, phases)
+        option = skill.build()
+    """
+
+    def _target_fn(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[Pose, Pose, str]:
+        robot_obj = objects[0]
+        current_pose = _get_current_ee_pose(state, robot_obj)
+
+        tx, ty, tz, tyaw = get_target_pose_fn(state, objects, params, cfg)
+        target_orn = p.getQuaternionFromEuler([0, cfg.robot_init_tilt, tyaw])
+        target_pose = Pose((tx, ty, tz), target_orn)
+
+        if finger_status is not None:
+            status = finger_status
+        else:
+            status = _get_finger_status(state, robot_obj, cfg)
+        return current_pose, target_pose, status
+
+    return Phase(
+        name=name,
+        action_type=PhaseAction.MOVE_TO_POSE,
+        target_fn=_target_fn,
+    )

--- a/predicators/ground_truth_models/skill_factories/pick.py
+++ b/predicators/ground_truth_models/skill_factories/pick.py
@@ -1,0 +1,157 @@
+"""Pick skill factory: creates a multi-phase pick-and-lift controller.
+
+This module provides ``create_pick_skill``, which builds a
+``ParameterizedOption`` that picks up an object by:
+
+  1. Moving above the object at ``config.transport_z`` (closed gripper).
+  2. Descending to the grasp height (open gripper, collision-free via BiRRT).
+  3. Closing the gripper.
+  4. Lifting slightly above the grasp height.
+
+The caller supplies a single callback ``get_target_pose_fn`` that extracts
+the object's ``(x, y, z, yaw)`` from the current state.  All environment-
+specific logic lives in this callback; the factory handles motion planning,
+IK, and phase sequencing.
+
+Continuous parameters: ``(grasp_z_offset,)``
+
+Example::
+
+    from predicators.ground_truth_models.skill_factories import (
+        SkillConfig, create_pick_skill,
+    )
+
+    config = SkillConfig(
+        robot=pybullet_robot,
+        open_fingers_joint=pybullet_robot.open_fingers,
+        closed_fingers_joint=pybullet_robot.closed_fingers,
+        fingers_state_to_joint=MyEnv._fingers_state_to_joint,
+        transport_z=0.8,
+    )
+
+    def _get_jug_pose(state, objects, params, config):
+        _, jug = objects
+        return (state.get(jug, "x"), state.get(jug, "y"),
+                state.get(jug, "z"), state.get(jug, "rot"))
+
+    PickJug = create_pick_skill(
+        name="PickJug",
+        types=[robot_type, jug_type],
+        config=config,
+        get_target_pose_fn=_get_jug_pose,
+    )
+"""
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from predicators.ground_truth_models.skill_factories.base import Phase, \
+    PhaseAction, PhaseSkill, SkillConfig, TargetPoseFn, build_params_space
+from predicators.ground_truth_models.skill_factories.move_to import \
+    make_move_to_phase
+from predicators.structs import Array, Object, ParameterizedOption, State, Type
+
+# Canonical continuous parameters for Pick.
+_PICK_PARAMS = [
+    ("grasp_z_offset (height above object origin to close gripper)", 0.0, 0.1),
+]
+
+
+def create_pick_skill(
+    name: str,
+    types: Sequence[Type],
+    config: SkillConfig,
+    get_target_pose_fn: TargetPoseFn,
+) -> ParameterizedOption:
+    """Create a multi-phase pick skill that grasps and lifts an object.
+
+    Phases:
+        0. **MoveAbove** -- Move above the object at ``config.transport_z``
+           with closed gripper.
+        1. **MoveToGrasp** -- Descend to object z + ``grasp_z_offset``
+           with open gripper (collision-free via BiRRT).
+        2. **Grasp** -- Close fingers.
+        3. **LiftSlightly** -- Lift slightly above the grasp height.
+
+    Continuous parameters:
+        ``(grasp_z_offset,)`` -- offset added to z returned by
+        ``get_target_pose_fn`` for the descend height.
+
+    Args:
+        name: Option name used for logging and matching.
+        types: Ordered object types.  First element must be the robot type.
+        config: Shared skill configuration (``config.transport_z`` is used).
+        get_target_pose_fn: Callback returning ``(x, y, z, yaw)`` from
+            ``(state, objects, params, config)``.  ``params`` will be empty.
+
+    Returns:
+        A ``ParameterizedOption`` implementing the pick skill.
+    """
+    params_space, params_description = build_params_space(_PICK_PARAMS)
+    _empty = np.array([], dtype=np.float32)
+    _shared: dict = {}
+
+    def _close_fingers_target(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float]:
+        del params
+        robot_obj = objects[0]
+        current = cfg.fingers_state_to_joint(cfg.robot,
+                                             state.get(robot_obj, "fingers"))
+        target = cfg.closed_fingers_joint - 0.01
+        return current, target
+
+    def _above_pose(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float, float, float]:
+        del params
+        x, y, _, yaw = get_target_pose_fn(state, objects, _empty, cfg)
+        return x, y, cfg.transport_z, yaw
+
+    def _descend_pose(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float, float, float]:
+        grasp_z_offset = float(params[0])
+        x, y, z, yaw = get_target_pose_fn(state, objects, _empty, cfg)
+        grasp_z = z + grasp_z_offset
+        _shared["grasp_z"] = grasp_z
+        return x, y, grasp_z, yaw
+
+    def _slight_lift_pose(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float, float, float]:
+        x, y, _, yaw = get_target_pose_fn(state, objects, _empty, cfg)
+        return x, y, _shared["grasp_z"] + 0.01, yaw
+
+    phases = []
+    phases.extend([
+        make_move_to_phase("MoveAbove", _above_pose, "closed"),
+        make_move_to_phase("MoveToGrasp", _descend_pose, "open"),
+        Phase(
+            name="Grasp",
+            action_type=PhaseAction.CHANGE_FINGERS,
+            target_fn=_close_fingers_target,
+            terminal_fn=None,
+        ),
+        make_move_to_phase("LiftSlightly", _slight_lift_pose, "closed")
+    ])
+
+    return PhaseSkill(name,
+                      types,
+                      params_space,
+                      config,
+                      phases,
+                      params_description=params_description).build()

--- a/predicators/ground_truth_models/skill_factories/place.py
+++ b/predicators/ground_truth_models/skill_factories/place.py
@@ -1,0 +1,141 @@
+"""Place skill factory: creates a multi-phase place controller.
+
+This module provides ``create_place_skill``, which builds a
+``ParameterizedOption`` that places a held object by:
+
+  1. Moving directly to the release position (collision-free via BiRRT).
+  2. Opening the gripper to release.
+  3. Retreating back up to ``config.transport_z``.
+
+When ``use_move_above=True``, an extra MoveAbove phase is inserted before
+the descent, moving to ``config.transport_z`` first.
+
+The placement target ``(target_x, target_y, target_yaw)`` and
+``release_z`` are all provided as continuous parameters -- no callback
+is needed.
+
+Continuous parameters: ``(target_x, target_y, release_z, target_yaw)``
+
+Example::
+
+    from predicators.ground_truth_models.skill_factories import (
+        SkillConfig, create_place_skill,
+    )
+
+    Place = create_place_skill(
+        name="Place",
+        types=[robot_type],
+        config=config,
+    )
+"""
+
+from typing import Sequence, Tuple
+
+import numpy as np
+
+from predicators.ground_truth_models.skill_factories.base import Phase, \
+    PhaseAction, PhaseSkill, SkillConfig, build_params_space
+from predicators.ground_truth_models.skill_factories.move_to import \
+    make_move_to_phase
+from predicators.structs import Array, Object, ParameterizedOption, State, Type
+
+# Canonical continuous parameters for Place.
+_PLACE_PARAMS = [
+    ("target_x (world x position for placement)", 0.4, 1.1),
+    ("target_y (world y position for placement)", 1.1, 1.6),
+    ("release_z (world z height to open gripper)", 0.5, 0.6),
+    ("target_yaw (placement orientation in radians)", -np.pi, np.pi),
+]
+
+
+def create_place_skill(
+    name: str,
+    types: Sequence[Type],
+    config: SkillConfig,
+    use_move_above: bool = False,
+) -> ParameterizedOption:
+    """Create a multi-phase place skill that releases a held object.
+
+    By default (``use_move_above=False``), the skill moves directly to the
+    release position, relying on BiRRT for collision avoidance:
+
+        0. **MoveToDrop** -- Move to ``(target_x, target_y, release_z)``.
+        1. **OpenFingers** -- Release the object.
+        2. **Retreat** -- Rise to ``config.transport_z``.
+
+    With ``use_move_above=True``, an extra phase is prepended:
+
+        0. **MoveAbove** -- Move to ``(target_x, target_y, transport_z)``.
+        1. **Descend** -- Lower to ``release_z``.
+        2. **OpenFingers** -- Release the object.
+        3. **Retreat** -- Rise to ``config.transport_z``.
+
+    Continuous parameters:
+        ``(target_x, target_y, release_z, target_yaw)`` -- placement
+        position, orientation, and release height.
+
+    Args:
+        name: Option name used for logging and matching.
+        types: Ordered object types.  First element must be the robot type.
+        config: Shared skill configuration (``config.transport_z`` is used).
+        use_move_above: If True, add a MoveAbove phase before descending.
+
+    Returns:
+        A ``ParameterizedOption`` implementing the place skill.
+    """
+    params_space, params_description = build_params_space(_PLACE_PARAMS)
+
+    def _open_fingers_target(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float]:
+        del params
+        robot_obj = objects[0]
+        current = cfg.fingers_state_to_joint(cfg.robot,
+                                             state.get(robot_obj, "fingers"))
+        target = cfg.open_fingers_joint - 0.01
+        return current, target
+
+    def _above_pose(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float, float, float]:
+        del state, objects  # unused
+        x, y, yaw = float(params[0]), float(params[1]), float(params[3])
+        return x, y, cfg.transport_z, yaw
+
+    def _drop_pose(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float, float, float]:
+        del state, objects, cfg  # unused
+        x, y = float(params[0]), float(params[1])
+        drop_z, yaw = float(params[2]), float(params[3])
+        return x, y, drop_z, yaw
+
+    phases = []
+    if use_move_above:
+        phases.append(make_move_to_phase("MoveAbove", _above_pose, "closed"))
+    phases.extend([
+        make_move_to_phase("Descend" if use_move_above else "MoveToDrop",
+                           _drop_pose, "closed"),
+        Phase(
+            name="OpenFingers",
+            action_type=PhaseAction.CHANGE_FINGERS,
+            target_fn=_open_fingers_target,
+        ),
+        make_move_to_phase("Retreat", _above_pose, "open"),
+    ])
+
+    return PhaseSkill(name,
+                      types,
+                      params_space,
+                      config,
+                      phases,
+                      params_description=params_description).build()

--- a/predicators/ground_truth_models/skill_factories/pour.py
+++ b/predicators/ground_truth_models/skill_factories/pour.py
@@ -1,0 +1,152 @@
+"""Pour skill factory: creates a multi-phase pour controller.
+
+This module provides ``create_pour_skill``, which builds a
+``ParameterizedOption`` that pours from a held container (e.g. jug) into a
+target (e.g. cup) by:
+
+  1. Moving to the pour position (cup + offsets, adjusted for jug displacement).
+  2. Tilting the end-effector to a fixed pour angle (π/4).
+
+The tilt phase uses incremental IK (``use_motion_planning=False``) for fine
+orientation control.
+
+Continuous parameters: none — all offsets are fixed constants.
+
+The ``get_target_pose_fn`` callback should return the **cup position**
+``(cup_x, cup_y, cup_z, yaw)``.  The skill internally computes the robot
+EE target by applying the fixed offsets and the jug-to-robot displacement.
+
+Example::
+
+    from predicators.ground_truth_models.skill_factories import (
+        SkillConfig, create_pour_skill,
+    )
+
+    def _get_cup_pose(state, objects, params, config):
+        _, jug, cup = objects
+        return (state.get(cup, "x"), state.get(cup, "y"),
+                state.get(cup, "z"), config.robot_init_wrist)
+
+    Pour = create_pour_skill(
+        name="Pour",
+        types=[robot_type, jug_type, cup_type],
+        config=config,
+        get_target_pose_fn=_get_cup_pose,
+    )
+"""
+
+from typing import Sequence, Tuple
+
+import numpy as np
+import pybullet as p
+
+from predicators.ground_truth_models.skill_factories.base import Phase, \
+    PhaseAction, PhaseSkill, SkillConfig, TargetPoseFn, build_params_space
+from predicators.ground_truth_models.skill_factories.move_to import \
+    make_move_to_phase
+from predicators.pybullet_helpers.geometry import Pose
+from predicators.structs import Array, Object, ParameterizedOption, State, Type
+
+# Canonical continuous parameters for Pour (none remaining).
+_POUR_PARAMS = []
+
+# Fixed pour tilt angle (radians).
+_POUR_TILT = np.pi / 4
+
+# Fixed absolute z height for pour target.
+_POUR_Z = 0.65625
+
+# Fixed y offset from cup to pour target.
+_POUR_Y_OFF = -0.135
+
+
+def create_pour_skill(
+    name: str,
+    types: Sequence[Type],
+    config: SkillConfig,
+    get_target_pose_fn: TargetPoseFn,
+) -> ParameterizedOption:
+    """Create a multi-phase pour skill that tilts to pour liquid.
+
+    Phases:
+        0. **MoveToTarget** -- Move to the pour position at pour height.
+        1. **TiltToPour** -- Tilt the EE to a fixed pour angle (π/4). Uses
+           incremental IK, not BiRRT, for fine orientation control.
+
+    Continuous parameters:
+        None -- all offsets are fixed constants.
+
+    Args:
+        name: Option name used for logging and matching.
+        types: Ordered object types.  ``[robot, jug, cup]``.
+        config: Shared skill configuration.
+        get_target_pose_fn: Callback returning the **cup position** as
+            ``(x, y, z, yaw)`` from ``(state, objects, params, config)``.
+
+    Returns:
+        A ``ParameterizedOption`` implementing the pour skill.
+    """
+    params_space, params_description = build_params_space(_POUR_PARAMS)
+    _empty = np.array([], dtype=np.float32)
+
+    def _robot_ee_target(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float, float, float]:
+        """Compute robot EE target from cup position + offsets + jug
+        displacement."""
+        # Cup position from callback
+        cx, cy, cz, yaw = get_target_pose_fn(state, objects, _empty, cfg)
+        # Pour target for jug (all offsets are fixed constants)
+        pour_x, pour_y = cx, cy + _POUR_Y_OFF
+        # Jug base z = robot EE z minus handle-to-base distance
+        robot_obj, jug_obj = objects[0], objects[1]
+        jug_x = state.get(jug_obj, "x")
+        jug_y = state.get(jug_obj, "y")
+        handle_h = 0.1
+        jug_z = state.get(robot_obj, "z") - handle_h
+        # Robot target = current robot + displacement to move jug to pour pos
+        robot_x = state.get(robot_obj, "x") + (pour_x - jug_x)
+        robot_y = state.get(robot_obj, "y") + (pour_y - jug_y)
+        robot_z = state.get(robot_obj, "z") + (_POUR_Z - jug_z)
+        return (robot_x, robot_y, robot_z, yaw)
+
+    def _tilt_target(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[Pose, Pose, str]:
+        robot_obj = objects[0]
+        current_position = (state.get(robot_obj,
+                                      "x"), state.get(robot_obj, "y"),
+                            state.get(robot_obj, "z"))
+        current_orn = p.getQuaternionFromEuler(
+            [0, state.get(robot_obj, "tilt"),
+             state.get(robot_obj, "wrist")])
+        current_pose = Pose(current_position, current_orn)
+        tx, ty, tz, tyaw = _robot_ee_target(state, objects, params, cfg)
+        target_orn = p.getQuaternionFromEuler([0, _POUR_TILT, tyaw])
+        target_pose = Pose((tx, ty, tz), target_orn)
+        return current_pose, target_pose, "closed"
+
+    phases = [
+        # Phase 0: Move to pour position
+        make_move_to_phase("MoveToTarget", _robot_ee_target, "closed"),
+        # Phase 1: Tilt EE to pour liquid into target
+        Phase(
+            name="TiltToPour",
+            action_type=PhaseAction.MOVE_TO_POSE,
+            target_fn=_tilt_target,
+            terminal_fn=None,
+        ),
+    ]
+
+    return PhaseSkill(name,
+                      types,
+                      params_space,
+                      config,
+                      phases,
+                      params_description=params_description).build()

--- a/predicators/ground_truth_models/skill_factories/push.py
+++ b/predicators/ground_truth_models/skill_factories/push.py
@@ -1,0 +1,205 @@
+"""Push skill factory: creates a multi-phase push controller.
+
+This module provides ``create_push_skill``, which builds a
+``ParameterizedOption`` that pushes an object (e.g. domino, switch, button)
+using a standard 4-waypoint trajectory:
+
+  1. Closing the gripper.
+  2. Moving above & behind the target at ``config.transport_z``.
+  3. Descending to contact height (target z + ``contact_z_offset``).
+  4. Pushing to the target position along its facing direction.
+  5. Retreating to ``config.robot_home_pos``.
+  6. Opening the gripper.
+
+The "facing direction" is derived from the yaw returned by
+``get_target_pose_fn`` as ``(sin(yaw), cos(yaw))``.  "Behind" means
+opposite to the facing direction.
+
+``config.robot_home_pos`` **must** be set.
+
+Continuous parameters: ``(approach_distance, contact_z_offset)``
+
+Example::
+
+    from predicators.ground_truth_models.skill_factories import (
+        SkillConfig, create_push_skill,
+    )
+
+    config = SkillConfig(
+        robot=pybullet_robot,
+        open_fingers_joint=pybullet_robot.open_fingers,
+        closed_fingers_joint=pybullet_robot.closed_fingers,
+        fingers_state_to_joint=MyEnv._fingers_state_to_joint,
+        robot_home_pos=(MyEnv.robot_init_x, MyEnv.robot_init_y,
+                        MyEnv.robot_init_z),
+    )
+
+    def _get_domino_pose(state, objects, params, config):
+        _, domino = objects
+        return (state.get(domino, "x"), state.get(domino, "y"),
+                state.get(domino, "z"), state.get(domino, "rot"))
+
+    Push = create_push_skill(
+        name="Push",
+        types=[robot_type, domino_type],
+        config=config,
+        get_target_pose_fn=_get_domino_pose,
+    )
+"""
+
+from typing import Callable, List, Sequence, Tuple
+
+import numpy as np
+
+from predicators.ground_truth_models.skill_factories.base import Phase, \
+    PhaseAction, PhaseSkill, SkillConfig, TargetPoseFn, build_params_space
+from predicators.ground_truth_models.skill_factories.move_to import \
+    make_move_to_phase
+from predicators.structs import Array, Object, ParameterizedOption, State, Type
+
+# Canonical continuous parameters for Push.
+_PUSH_PARAMS = [
+    ("approach_distance (dist behind target along facing dir to start push)",
+     0.00, 0.05),
+    ("contact_z_offset (height above target z for contact)", 0.0, 0.1),
+]
+
+
+def create_push_skill(
+    name: str,
+    types: Sequence[Type],
+    config: SkillConfig,
+    get_target_pose_fn: TargetPoseFn,
+) -> ParameterizedOption:
+    """Create a multi-phase push skill with a standard 4-waypoint trajectory.
+
+    Phases:
+        0. **CloseFingers** -- Close the gripper before approaching.
+        1. **Waypoint_0** -- Move above & behind the target at
+           ``config.transport_z``, offset by ``approach_distance``
+           opposite the facing direction.
+        2. **Waypoint_1** -- Descend to contact height
+           (target z + ``contact_z_offset``) at the same behind position.
+        3. **Waypoint_2** -- Push forward to the target position.
+        4. **Waypoint_3** -- Retreat to ``config.robot_home_pos``.
+        5. **OpenFingers** -- Open the gripper.
+
+    Continuous parameters:
+        ``(approach_distance, contact_z_offset)``
+
+    Args:
+        name: Option name used for logging and matching.
+        types: Ordered object types.  First element must be the robot type.
+        config: Shared skill configuration.  ``config.robot_home_pos`` and
+            ``config.transport_z`` must be set.
+        get_target_pose_fn: Callback returning ``(x, y, z, yaw)`` from
+            ``(state, objects, params, config)``.  ``params`` will be empty.
+
+    Returns:
+        A ``ParameterizedOption`` implementing the push skill.
+    """
+    if config.robot_home_pos is None:
+        raise ValueError(
+            "config.robot_home_pos must be set for create_push_skill.")
+
+    params_space, params_description = build_params_space(_PUSH_PARAMS)
+    _empty = np.array([], dtype=np.float32)
+
+    # -- Standard 4-waypoint trajectory ----------------------------------
+
+    def _waypoints(
+        ox: float,
+        oy: float,
+        oz: float,
+        oyaw: float,
+        cfg: SkillConfig,
+        s_offset_x: float,
+        s_offset_z: float,
+    ) -> List[Tuple[float, float, float, float, str]]:
+        assert cfg.robot_home_pos is not None
+        obj_xy = np.array([ox, oy])
+        facing = np.array([np.sin(oyaw), np.cos(oyaw)])
+        behind_xy = obj_xy - facing * s_offset_x
+        push_xy = obj_xy
+        home_xy = np.array(cfg.robot_home_pos[:2])
+        home_z = cfg.robot_home_pos[2]
+        ee_yaw = oyaw + np.pi / 2
+        return [
+            (*behind_xy, cfg.transport_z, ee_yaw, "closed"),
+            (*behind_xy, oz + s_offset_z, ee_yaw, "closed"),
+            (*push_xy, oz + s_offset_z, ee_yaw, "closed"),
+            (*home_xy, home_z, ee_yaw, "closed"),
+        ]
+
+    # -- Phase construction -----------------------------------------------
+
+    def _close_fingers_target(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float]:
+        del params
+        robot_obj = objects[0]
+        current = cfg.fingers_state_to_joint(cfg.robot,
+                                             state.get(robot_obj, "fingers"))
+        target = cfg.closed_fingers_joint - 0.01
+        return current, target
+
+    def _open_fingers_target(
+        state: State,
+        objects: Sequence[Object],
+        params: Array,
+        cfg: SkillConfig,
+    ) -> Tuple[float, float]:
+        del params
+        robot_obj = objects[0]
+        current = cfg.fingers_state_to_joint(cfg.robot,
+                                             state.get(robot_obj, "fingers"))
+        target = cfg.open_fingers_joint - 0.01
+        return current, target
+
+    def _make_waypoint_position_fn(
+        waypoint_idx: int,
+    ) -> Callable[[State, Sequence[Object], Array, SkillConfig], Tuple[
+            float, float, float, float]]:
+
+        def _get_target(
+            state: State,
+            objects: Sequence[Object],
+            params: Array,
+            cfg: SkillConfig,
+        ) -> Tuple[float, float, float, float]:
+            s_ox = float(params[0])
+            s_oz = float(params[1])
+            x, y, z, yaw = get_target_pose_fn(state, objects, _empty, cfg)
+            wps = _waypoints(x, y, z, yaw, cfg, s_ox, s_oz)
+            wx, wy, wz, wyaw, _ = wps[waypoint_idx]
+            return wx, wy, wz, wyaw
+
+        return _get_target
+
+    phases: List[Phase] = []
+    phases.append(
+        Phase(name="CloseFingers",
+              action_type=PhaseAction.CHANGE_FINGERS,
+              target_fn=_close_fingers_target))
+
+    for i in range(4):
+        phases.append(
+            make_move_to_phase(
+                name=f"Waypoint_{i}",
+                get_target_pose_fn=_make_waypoint_position_fn(i),
+                finger_status="closed"))
+
+    phases.append(
+        Phase(name="OpenFingers",
+              action_type=PhaseAction.CHANGE_FINGERS,
+              target_fn=_open_fingers_target))
+
+    return PhaseSkill(name,
+                      types,
+                      params_space,
+                      config,
+                      phases,
+                      params_description=params_description).build()

--- a/predicators/ground_truth_models/skill_factories/wait.py
+++ b/predicators/ground_truth_models/skill_factories/wait.py
@@ -1,0 +1,88 @@
+"""Wait skill factory: holds current pose with finger drift resistance.
+
+This module provides ``create_wait_option``, which builds a
+``ParameterizedOption`` that holds the robot's current joint positions
+while nudging fingers toward their current open/closed state to resist
+drift.  The option is always initiable and never terminates.
+
+Example::
+
+    from predicators.ground_truth_models.skill_factories import (
+        SkillConfig, create_wait_option,
+    )
+
+    Wait = create_wait_option("Wait", config, robot_type)
+"""
+
+from typing import Dict, Optional, Sequence, Tuple, cast
+
+import numpy as np
+from gym.spaces import Box
+
+from predicators import utils
+from predicators.ground_truth_models.skill_factories.base import SkillConfig
+from predicators.structs import Action, Array, Object, ParameterizedOption, \
+    State, Type
+
+
+def create_wait_option(
+    name: str,
+    config: SkillConfig,
+    robot_type: Type,
+    params_description: Optional[Tuple[str, ...]] = None,
+) -> ParameterizedOption:
+    """Create a wait (no-op) option that holds the robot's current pose.
+
+    Nudges fingers toward their current open/closed state to resist drift,
+    keeps all other joints at their current positions, and never terminates.
+
+    Args:
+        name: Option name (e.g. "Wait").
+        config: Shared skill configuration.  See ``SkillConfig``.
+        robot_type: The robot ``Type`` object.
+
+    Returns:
+        A ``ParameterizedOption`` with ``initiable=True`` and
+        ``terminal=False`` always.
+
+    Example::
+
+        wait = create_wait_option("Wait", config, robot_type)
+    """
+    robot = config.robot
+    mid_point = (config.open_fingers_joint + config.closed_fingers_joint) / 2
+
+    def _policy(state: State, memory: Dict, objects: Sequence[Object],
+                params: Array) -> Action:
+        del memory, params
+        robot_obj = objects[0]
+
+        current_joint = config.fingers_state_to_joint(
+            robot, state.get(robot_obj, "fingers"))
+        if current_joint > mid_point:  # currently open -- nudge open
+            finger_delta = config.finger_action_nudge_magnitude
+        else:  # currently closed -- nudge closed
+            finger_delta = -config.finger_action_nudge_magnitude
+
+        pb_state = cast(utils.PyBulletState, state)
+        joint_positions = pb_state.joint_positions.copy()
+        f_action = joint_positions[robot.left_finger_joint_idx] + finger_delta
+        joint_positions[robot.left_finger_joint_idx] = f_action
+        joint_positions[robot.right_finger_joint_idx] = f_action
+
+        return Action(
+            np.clip(
+                np.array(joint_positions, dtype=np.float32),
+                robot.action_space.low,
+                robot.action_space.high,
+            ))
+
+    return ParameterizedOption(
+        name,
+        types=[robot_type],
+        params_space=Box(0, 1, (0, )),
+        policy=_policy,
+        initiable=lambda _1, _2, _3, _4: True,
+        terminal=lambda _1, _2, _3, _4: False,
+        params_description=params_description,
+    )


### PR DESCRIPTION
## Summary
- Generic pick, place, pour, push, move_to, and wait skills
- Phase-based trajectories with BiRRT motion planning
- Canonical continuous parameters reusable across all PyBullet envs
- PhaseSkill base class with configurable trajectory generation

## PR Stack
1-3 ← **4. → This PR** — Skill factories → 5-10