### PR TITLE
Add agent bilevel approach

### DIFF
--- a/predicators/approaches/agent_bilevel_approach.py
+++ b/predicators/approaches/agent_bilevel_approach.py
@@ -1,0 +1,625 @@
+"""Agent bilevel approach: agent produces plan sketch, search refines params.
+
+The agent generates a plan sketch — a sequence of parameterized skills with
+object bindings but without continuous parameters, plus optional subgoal
+atoms after each step.  A backtracking search then samples continuous
+parameters and validates each step via the option model.
+
+Example command::
+
+    python predicators/main.py --env pybullet_domino \
+        --approach agent_bilevel --seed 0 \
+        --num_train_tasks 1 --num_test_tasks 1 \
+        --num_online_learning_cycles 1 --explorer agent
+"""
+import dataclasses
+import logging
+import re
+import time
+from typing import Callable, Dict, List, Optional, Sequence, Set, Tuple
+
+import numpy as np
+
+from predicators import utils
+from predicators.approaches import ApproachFailure
+from predicators.approaches.agent_planner_approach import AgentPlannerApproach
+from predicators.settings import CFG
+from predicators.structs import Action, GroundAtom, Object, \
+    ParameterizedOption, Predicate, State, Task, Type, _Option
+
+
+@dataclasses.dataclass
+class _SketchStep:
+    """One step in an agent-produced plan sketch."""
+    option: ParameterizedOption
+    objects: Sequence[Object]
+    subgoal_atoms: Optional[Set[GroundAtom]]  # None = no subgoal constraint
+
+
+class AgentBilevelApproach(AgentPlannerApproach):
+    """Bilevel planning: agent proposes discrete skeleton, search refines
+    continuous parameters.
+
+    Extends AgentPlannerApproach — reuses agent session, tools, trajectory
+    management, exploration, save/load.  Overrides solving to separate
+    discrete planning from continuous refinement.
+    """
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "agent_bilevel"
+
+    # ------------------------------------------------------------------ #
+    # System prompt (simplified — no parameter tuning workflow)
+    # ------------------------------------------------------------------ #
+
+    def _get_agent_system_prompt(self) -> str:
+        return (
+            "You are a planning agent. You observe task environments through "
+            "inspection tools and generate plan sketches to achieve goals. "
+            "You have access to read-only tools to inspect predicates, "
+            "options, trajectories, and training tasks.\n\n"
+            "Your job is to produce a DISCRETE plan sketch: the sequence of "
+            "skills (parameterized options) and their object arguments, plus "
+            "optional subgoal atoms that should hold after each step. You do "
+            "NOT need to specify continuous parameters — those will be found "
+            "automatically by a search procedure.\n\n"
+            "Some effects may not be immediate — if an action triggers a "
+            "delayed process (e.g. water filling, dominoes cascading, "
+            "heating), insert a Wait after it so the effect has time to "
+            "occur before the next action.\n\n"
+            "## Subgoal Annotations\n"
+            "After each step you can annotate which predicate atoms should "
+            "hold after that step succeeds. This helps the search procedure "
+            "verify progress. Use the format:\n"
+            "  OptionName(obj1:type1, obj2:type2) -> {Pred(obj1:type1), "
+            "Pred2(obj1:type1, obj2:type2)}\n"
+            "Always use typed references (obj:type) in subgoal atoms.\n"
+            "Subgoal annotations are optional but improve search efficiency.")
+
+    # ------------------------------------------------------------------ #
+    # Solve prompt (no continuous params, subgoal format)
+    # ------------------------------------------------------------------ #
+
+    def _build_solve_prompt(self, task: Task) -> str:
+        """Build prompt asking for a plan sketch without continuous params."""
+        init_state = task.init
+        objects = list(init_state)
+
+        # Objects
+        obj_strs = []
+        for obj in sorted(objects, key=lambda o: o.name):
+            obj_strs.append(f"  {obj.name}: {obj.type.name}")
+
+        # Goal
+        goal_strs = [str(a) for a in sorted(task.goal, key=str)]
+
+        # Options (show params_space info so agent understands what's tunable)
+        option_strs = []
+        for opt in sorted(self._get_all_options(), key=lambda o: o.name):
+            type_sig = ", ".join(t.name for t in opt.types)
+            params_dim = opt.params_space.shape[0]
+            if params_dim > 0:
+                low = opt.params_space.low.tolist()
+                high = opt.params_space.high.tolist()
+                if opt.params_description:
+                    desc = ", ".join(opt.params_description)
+                    param_info = (f"  [auto-searched params: {desc}, "
+                                  f"range {low} to {high}]")
+                else:
+                    param_info = (f"  [auto-searched: {params_dim}d, "
+                                  f"range {low} to {high}]")
+            else:
+                param_info = ""
+            option_strs.append(f"  {opt.name}({type_sig}){param_info}")
+
+        # Current atoms
+        atoms = utils.abstract(init_state, self._get_all_predicates())
+        atom_strs = [str(a) for a in sorted(atoms, key=str)]
+
+        # Trajectory summary
+        traj_summary = self._build_trajectory_summary()
+
+        # State features
+        state_str = init_state.dict_str(indent=2)
+
+        # Available tools
+        tool_names = self._get_agent_tool_names()
+        tools_str = ""
+        if tool_names:
+            tool_list = "\n".join(f"  - {t}" for t in tool_names)
+            tools_str = f"\n## Available Tools\n{tool_list}\n"
+
+        # Natural language goal
+        goal_nl_section = ""
+        if task.goal_nl:
+            goal_nl_section = f"\n## Goal Description\n{task.goal_nl}\n"
+
+        # Available predicates for subgoal annotations
+        pred_strs = []
+        for pred in sorted(self._get_all_predicates(), key=lambda p: p.name):
+            type_sig = ", ".join(t.name for t in pred.types)
+            pred_strs.append(f"  {pred.name}({type_sig})")
+
+        prompt = f"""You are solving a task. Generate a plan sketch to achieve the goal.
+{goal_nl_section}
+## Goal Atoms
+{chr(10).join(goal_strs)}
+
+## Initial State Atoms
+{chr(10).join(atom_strs)}
+
+## Initial State Features
+{state_str}
+
+## Objects
+{chr(10).join(obj_strs)}
+
+## Available Options
+{chr(10).join(option_strs)}
+
+## Available Predicates (for subgoal annotations)
+{chr(10).join(pred_strs)}
+{traj_summary}{tools_str}
+## Instructions
+Use your available tools to inspect the environment before producing the plan.
+
+Generate a plan SKETCH — the sequence of options with object arguments, but \
+WITHOUT continuous parameters. Continuous parameters will be found \
+automatically by a backtracking search procedure.
+
+Optionally annotate subgoal atoms that should hold after each step. This \
+helps the search verify progress. Use `-> {{atoms}}` after each step.
+
+After any action whose desired subgoal depends on a delayed process (e.g. \
+water filling, dominoes cascading, heating), insert a Wait action.
+
+Output the plan sketch with one option per line in this format:
+  OptionName(obj1:type1, obj2:type2) -> {{Pred(obj1:type1), Pred2(obj1:type1, obj2:type2)}}
+
+Always use typed references (obj:type) in both option arguments AND subgoal \
+atoms. The `-> {{atoms}}` part is optional. If you omit it, the search will \
+only check that the option executed successfully (non-zero actions).
+
+Output ONLY the plan sketch lines at the end, after any analysis."""
+
+        return prompt
+
+    # ------------------------------------------------------------------ #
+    # Solving
+    # ------------------------------------------------------------------ #
+
+    def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
+        max_retries = CFG.agent_bilevel_max_retries
+        self._sync_tool_context()
+        self._tool_context.current_task = task
+        start = time.perf_counter()
+
+        for attempt in range(max_retries):
+            remaining = timeout - (time.perf_counter() - start)
+            if remaining <= 0:
+                break
+            try:
+                sketch = self._query_agent_for_plan_sketch(task)
+            except Exception as e:
+                logging.warning(
+                    f"Sketch query failed (attempt {attempt}): {e}")
+                continue
+
+            logging.info(
+                f"[{self._run_id}] Sketch (attempt {attempt}):\n" + "\n".join(
+                    f"  {i}: {s.option.name}({', '.join(o.name for o in s.objects)})"
+                    + (f" -> {{{', '.join(str(a) for a in s.subgoal_atoms)}}}"
+                       if s.subgoal_atoms else "")
+                    for i, s in enumerate(sketch)))
+
+            plan, success = self._refine_sketch(task, sketch, remaining)
+            if success:
+                plan_str = "\n".join(
+                    f"  {i}: {o.name}({', '.join(obj.name for obj in o.objects)})"
+                    f"[{', '.join(f'{p:.4f}' for p in o.params)}]"
+                    for i, o in enumerate(plan))
+                logging.info(
+                    f"[{self._run_id}] Refinement succeeded "
+                    f"(attempt {attempt}), {len(plan)} steps:\n{plan_str}")
+
+                # Forward validation: verify the plan works in
+                # continuous execution (no state resets between steps).
+                # if self._validate_plan_forward(task, plan):
+                return self._plan_to_policy(plan)
+                # logging.info("Forward validation failed; retrying.")
+            logging.info(f"Refinement failed (attempt {attempt}), "
+                         f"{len(sketch)} steps.")
+
+        raise ApproachFailure(
+            f"Bilevel solve failed after {max_retries} attempts.")
+
+    # ------------------------------------------------------------------ #
+    # Plan sketch extraction
+    # ------------------------------------------------------------------ #
+
+    def _query_agent_for_plan_sketch(self, task: Task) -> List[_SketchStep]:
+        """Query agent for a plan sketch and parse it."""
+        prompt = self._build_solve_prompt(task)
+        responses = self._query_agent_sync(prompt)
+        plan_text = self._extract_option_plan_text(responses)
+
+        if not plan_text:
+            n_responses = len(responses)
+            types = [r.get("type") for r in responses]
+            raise ApproachFailure(
+                f"Agent returned empty plan text. "
+                f"Got {n_responses} responses with types: {types}")
+
+        cleaned_text = self._strip_code_fences(plan_text)
+
+        # Phase 1: parse options + objects (no continuous params)
+        objects = list(task.init)
+        parsed = utils.parse_model_output_into_option_plan(
+            cleaned_text,
+            objects,
+            self._types,
+            self._get_all_options(),
+            parse_continuous_params=False)
+
+        if not parsed:
+            option_names = sorted(o.name for o in self._get_all_options())
+            raise ApproachFailure(f"Parsed empty plan sketch from agent.\n"
+                                  f"  Plan text:\n{plan_text}\n"
+                                  f"  Available option names: {option_names}")
+
+        # Phase 2: parse subgoal annotations from raw text
+        subgoals = self._parse_subgoal_annotations(cleaned_text,
+                                                   self._get_all_predicates(),
+                                                   objects)
+
+        # Zip into sketch steps
+        sketch = []
+        for i, (option, objs, _) in enumerate(parsed):
+            sg = subgoals[i] if i < len(subgoals) else None
+            sketch.append(
+                _SketchStep(option=option, objects=objs, subgoal_atoms=sg))
+
+        logging.info(f"[{self._run_id}] Agent produced sketch with "
+                     f"{len(sketch)} steps, "
+                     f"{sum(1 for s in sketch if s.subgoal_atoms)} "
+                     f"with subgoals.")
+        return sketch
+
+    def _parse_subgoal_annotations(
+        self,
+        text: str,
+        predicates: Set[Predicate],
+        objects: Sequence[Object],
+    ) -> List[Optional[Set[GroundAtom]]]:
+        """Parse ``-> {Pred(obj1, obj2), ...}`` annotations from plan text.
+
+        Returns a list parallel to the option lines.  Entries are None for
+        lines without annotations.
+        """
+        pred_map = {p.name: p for p in predicates}
+        obj_map = {o.name: o for o in objects}
+
+        # Regex: match -> { ... } after the option line
+        subgoal_re = re.compile(r'->\s*\{([^}]*)\}')
+        # Regex: match individual atoms like Pred(obj1, obj2)
+        atom_re = re.compile(r'(\w+)\(([^)]*)\)')
+
+        results: List[Optional[Set[GroundAtom]]] = []
+        option_names = {o.name for o in self._get_all_options()}
+
+        for line in text.split('\n'):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            # Check if this line starts with a valid option name
+            first_token = stripped.split('(')[0]
+            if first_token not in option_names:
+                continue
+
+            # This is an option line — check for subgoal annotation
+            sg_match = subgoal_re.search(stripped)
+            if not sg_match:
+                results.append(None)
+                continue
+
+            atoms_text = sg_match.group(1)
+            atoms: Set[GroundAtom] = set()
+            for atom_match in atom_re.finditer(atoms_text):
+                pred_name = atom_match.group(1)
+                # Handle both "obj" and "obj:type" formats
+                obj_names = [
+                    n.strip().split(':')[0]
+                    for n in atom_match.group(2).split(',')
+                ]
+
+                if pred_name not in pred_map:
+                    logging.warning(f"Unknown predicate in subgoal: "
+                                    f"{pred_name}")
+                    continue
+                pred = pred_map[pred_name]
+                try:
+                    objs = [obj_map[n] for n in obj_names]
+                except KeyError as e:
+                    logging.warning(f"Unknown object in subgoal: {e}")
+                    continue
+                if len(objs) != len(pred.types):
+                    logging.warning(
+                        f"Arity mismatch for {pred_name}: expected "
+                        f"{len(pred.types)}, got {len(objs)}")
+                    continue
+                atoms.add(GroundAtom(pred, objs))
+
+            results.append(atoms if atoms else None)
+
+        return results
+
+    # ------------------------------------------------------------------ #
+    # Backtracking refinement
+    # ------------------------------------------------------------------ #
+
+    def _refine_sketch(
+        self,
+        task: Task,
+        sketch: List[_SketchStep],
+        timeout: float,
+    ) -> Tuple[List[_Option], bool]:
+        """Backtracking search over continuous parameters for a plan sketch.
+
+        Returns ``(plan, success)``.  On success, ``plan`` is a list of
+        grounded options that achieves the task goal.  On failure, ``plan``
+        is the longest partial refinement found.
+        """
+        if not sketch:
+            return [], False
+
+        rng = np.random.default_rng(CFG.seed)
+        max_samples = CFG.agent_bilevel_max_samples_per_step
+        check_subgoals = CFG.agent_bilevel_check_subgoals
+        start_time = time.perf_counter()
+
+        n = len(sketch)
+        cur_idx = 0
+        num_tries = [0] * n
+        max_tries = [
+            max_samples if step.option.params_space.shape[0] > 0 else 1
+            for step in sketch
+        ]
+        plan: List[Optional[_Option]] = [None] * n
+        traj: List[Optional[State]] = [task.init] + [None] * n
+
+        total_samples = 0
+
+        while cur_idx < n:
+            elapsed = time.perf_counter() - start_time
+            if elapsed > timeout:
+                logging.info(
+                    f"Sketch refinement timed out after {elapsed:.1f}s "
+                    f"at step {cur_idx}/{n}, {total_samples} total samples.")
+                return [p for p in plan if p is not None], False
+
+            step = sketch[cur_idx]
+            num_tries[cur_idx] += 1
+            total_samples += 1
+            step_name = (f"{step.option.name}"
+                         f"({', '.join(o.name for o in step.objects)})")
+
+            # Optionally log state before sampling
+            if CFG.agent_bilevel_log_state:
+                logging.debug(
+                    f"  State before {step_name}:\n"
+                    f"{traj[cur_idx].pretty_str()}")
+
+            # Sample continuous parameters and ground option
+            params = self._sample_params(step.option, traj[cur_idx], rng)
+            grounded = step.option.ground(step.objects, params)
+            plan[cur_idx] = grounded
+
+            state = traj[cur_idx]
+            can_continue = False
+            fail_reason = "not initiable"
+
+            if grounded.initiable(state):
+                try:
+                    next_state, num_actions = \
+                        self._option_model.get_next_state_and_num_actions(
+                            state, grounded)
+                except utils.EnvironmentFailure as e:
+                    fail_reason = f"env failure: {e}"
+                else:
+                    if num_actions == 0:
+                        fail_reason = (
+                            self._option_model.last_execution_failure
+                            or "0 actions")
+                    else:
+                        traj[cur_idx + 1] = next_state
+                        # Check subgoals if specified
+                        if (check_subgoals and step.subgoal_atoms is not None):
+                            current_atoms = utils.abstract(
+                                next_state, self._get_all_predicates())
+                            if step.subgoal_atoms.issubset(current_atoms):
+                                can_continue = True
+                            else:
+                                missing = step.subgoal_atoms - current_atoms
+                                fail_reason = (
+                                    f"subgoal missing: "
+                                    f"{{{', '.join(str(a) for a in missing)}}}")
+                        else:
+                            can_continue = True
+                        # Final step: also check task goal
+                        if can_continue and cur_idx == n - 1:
+                            if not task.goal_holds(next_state):
+                                can_continue = False
+                                fail_reason = "goal not reached"
+
+            if can_continue:
+                logging.info(
+                    f"  Step {cur_idx}/{n} {step_name} OK "
+                    f"(sample {num_tries[cur_idx]}/{max_tries[cur_idx]})\n")
+                if CFG.agent_bilevel_log_state:
+                    logging.debug(
+                        f"  State after {step_name}:\n"
+                        f"{traj[cur_idx + 1].pretty_str()}")
+                cur_idx += 1
+            else:
+                logging.debug(
+                    f"  Step {cur_idx}/{n} {step_name} FAIL "
+                    f"(sample {num_tries[cur_idx]}/{max_tries[cur_idx]})"
+                    f": {fail_reason}")
+                # Backtrack: re-try current step or go back further
+                while num_tries[cur_idx] >= max_tries[cur_idx]:
+                    bt_name = (f"{sketch[cur_idx].option.name}"
+                               f"({', '.join(o.name for o in sketch[cur_idx].objects)})")
+                    logging.info(
+                        f"  Step {cur_idx}/{n} {bt_name} exhausted "
+                        f"{max_tries[cur_idx]} samples, backtracking")
+                    num_tries[cur_idx] = 0
+                    plan[cur_idx] = None
+                    traj[cur_idx + 1] = None
+                    cur_idx -= 1
+                    if cur_idx < 0:
+                        logging.info(
+                            f"Sketch refinement exhausted after "
+                            f"{total_samples} total samples.")
+                        return [], False
+
+        # All steps succeeded
+        assert all(p is not None for p in plan)
+        logging.info(f"Refinement complete: {total_samples} total samples "
+                     f"for {n} steps.")
+        return plan, True
+
+    def _sample_params(self, option: ParameterizedOption, state: State,
+                       rng: np.random.Generator) -> np.ndarray:
+        """Sample continuous parameters for an option.
+
+        Currently uniform random; hook point for future learned samplers.
+        """
+        if option.params_space.shape[0] == 0:
+            return np.array([], dtype=np.float32)
+        low = option.params_space.low
+        high = option.params_space.high
+        return rng.uniform(low, high).astype(np.float32)
+
+    # ------------------------------------------------------------------ #
+    # Forward validation
+    # ------------------------------------------------------------------ #
+
+    def _validate_plan_forward(
+        self,
+        task: Task,
+        plan: List[_Option],
+    ) -> bool:
+        """Re-execute the plan continuously in the option model's env.
+
+        Unlike refinement (which resets state between steps via
+        ``_reset_state``), this runs all options sequentially so that the
+        physics state carries forward naturally — matching how the main
+        env will execute during the real episode.
+
+        Returns True if the plan reaches the goal, False otherwise.
+        """
+        state = task.init
+        option_names = self._option_model._name_to_parameterized_option
+        predicates = self._get_all_predicates()
+        total_actions = 0
+
+        for i, grounded in enumerate(plan):
+            # Create a fresh option copy (same as the option model does).
+            env_param_opt = option_names.get(grounded.parent.name,
+                                             grounded.parent)
+            option_copy = env_param_opt.ground(grounded.objects,
+                                               grounded.params.copy())
+
+            if not option_copy.initiable(state):
+                logging.info(f"Forward validation: step {i} "
+                             f"({option_copy.name}) not initiable.")
+                return False
+
+            # Build a terminal condition that mirrors the option model:
+            # 1. The option's own terminal
+            # 2. terminate_on_repeat (stuck detection)
+            # 3. wait_option_terminate_on_atom_change
+            last_state_ref: List[Optional[State]] = [None]
+
+            def _terminal(s: State,
+                          oc: _Option = option_copy) -> bool:
+                if oc.terminal(s):
+                    return True
+                prev = last_state_ref[0]
+                if prev is not None:
+                    if (CFG.option_model_terminate_on_repeat
+                            and prev.allclose(s)):
+                        raise utils.OptionExecutionFailure(
+                            f"Option '{oc.name}' got stuck.")
+                    if (CFG.wait_option_terminate_on_atom_change
+                            and oc.name == "Wait"):
+                        cur_atoms = utils.abstract(s, predicates)
+                        prev_atoms = utils.abstract(prev, predicates)
+                        if cur_atoms != prev_atoms:
+                            last_state_ref[0] = s
+                            return True
+                last_state_ref[0] = s
+                return False
+
+            try:
+                traj = utils.run_policy_with_simulator(
+                    option_copy.policy,
+                    self._option_model._simulator,
+                    state,
+                    _terminal,
+                    max_num_steps=CFG.max_num_steps_option_rollout)
+            except (utils.OptionExecutionFailure,
+                    utils.EnvironmentFailure) as e:
+                logging.info(f"Forward validation: step {i} "
+                             f"({option_copy.name}) failed: {e}")
+                return False
+
+            if len(traj.actions) == 0:
+                logging.info(f"Forward validation: step {i} "
+                             f"({option_copy.name}) produced 0 actions.")
+                return False
+
+            total_actions += len(traj.actions)
+            state = traj.states[-1]
+            atoms = utils.abstract(state, predicates)
+            logging.debug(
+                f"Forward validation: step {i} "
+                f"({option_copy.name}) OK, {len(traj.actions)} actions. "
+                f"Atoms: {sorted(str(a) for a in atoms)}")
+
+        if not task.goal_holds(state):
+            atoms = utils.abstract(state, predicates)
+            goal_atoms = task.goal
+            missing = goal_atoms - atoms
+            logging.info(
+                f"Forward validation: goal not reached. "
+                f"Missing: {{{', '.join(str(a) for a in sorted(missing))}}}. "
+                f"State:\n{state.pretty_str()}")
+            return False
+
+        logging.info(f"Forward validation succeeded: {total_actions} "
+                     f"actions from {len(plan)} steps.")
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+
+    def _plan_to_policy(
+        self,
+        plan: List[_Option],
+    ) -> Callable[[State], Action]:
+        """Wrap a grounded option plan into a step-by-step policy."""
+        predicates = self._get_all_predicates()
+        policy = utils.option_plan_to_policy(
+            plan,
+            abstract_function=lambda s: utils.abstract(s, predicates))
+
+        def _policy(s: State) -> Action:
+            try:
+                return policy(s)
+            except utils.OptionExecutionFailure as e:
+                raise ApproachFailure(e.args[0], e.info)
+
+        return _policy

--- a/predicators/approaches/agent_planner_approach.py
+++ b/predicators/approaches/agent_planner_approach.py
@@ -58,6 +58,12 @@ class AgentPlannerApproach(AgentSessionMixin, BaseApproach):
             self._option_model = option_model
         else:
             self._option_model = create_option_model(CFG.option_model_name)
+        # Let the option model terminate Wait on atom change using the
+        # approach's predicates (which may include invented ones).
+        if CFG.wait_option_terminate_on_atom_change:
+            preds = self._get_all_predicates()
+            self._option_model._abstract_function = \
+                lambda s, _p=preds: utils.abstract(s, _p)
         self._online_learning_cycle = 0
         self._requests_train_task_idxs: Optional[List[int]] = None
         self._run_id = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -352,13 +358,6 @@ scene, then annotate_scene overlays markers on it."""
     # ------------------------------------------------------------------ #
 
     def _solve(self, task: Task, timeout: int) -> Callable[[State], Action]:
-        if CFG.agent_planner_isolate_test_session:
-            return self._solve_with_isolated_session(task, timeout)
-        return self._solve_shared_session(task, timeout)
-
-    def _solve_shared_session(self, task: Task,
-                              timeout: int) -> Callable[[State], Action]:
-        """Solve using the shared session (test queries stay in context)."""
         self._sync_tool_context()
         self._tool_context.current_task = task
         try:
@@ -378,49 +377,26 @@ scene, then annotate_scene overlays markers on it."""
 
         return _policy
 
-    def _solve_with_isolated_session(
-            self, task: Task, timeout: int) -> Callable[[State], Action]:
-        """Solve in a fresh session so test queries don't accumulate in the
-        learning session.
+    # ------------------------------------------------------------------ #
+    # Test phase lifecycle
+    # ------------------------------------------------------------------ #
 
-        The learning conversation log is injected as context so the test
-        session retains knowledge from learning.
-        """
-        learning_session = self._agent_session
-        learning_log = (learning_session.conversation_log
-                        if learning_session is not None else [])
-        self._agent_session = None
+    def begin_test_phase(self) -> None:
+        """Snapshot the learning conversation log before testing."""
+        if self._agent_session is not None:
+            import copy
+            self._pre_test_conversation_log = copy.deepcopy(
+                self._agent_session.conversation_log)
+        else:
+            self._pre_test_conversation_log = None
 
-        try:
-            self._sync_tool_context()
-            self._tool_context.current_task = task
-
-            # Inject learning context into the fresh test session
-            if learning_log:
-                context_msg = self._build_learning_context(learning_log)
-                self._query_agent_sync(context_msg)
-
-            try:
-                option_plan = self._query_agent_for_option_plan(task)
-            except Exception as e:
-                raise ApproachFailure(
-                    f"Agent failed to produce option plan: {e}")
-
-            preds = self._get_all_predicates()
-            policy = utils.option_plan_to_policy(
-                option_plan,
-                abstract_function=lambda s: utils.abstract(s, preds))
-
-            def _policy(s: State) -> Action:
-                try:
-                    return policy(s)
-                except utils.OptionExecutionFailure as e:
-                    raise ApproachFailure(e.args[0], e.info)
-
-            return _policy
-        finally:
-            self._close_agent_session()
-            self._agent_session = learning_session
+    def end_test_phase(self) -> None:
+        """Restore the conversation log to its pre-test state."""
+        if self._agent_session is not None \
+                and self._pre_test_conversation_log is not None:
+            self._agent_session._conversation_log = \
+                self._pre_test_conversation_log
+        self._pre_test_conversation_log = None
 
     def _query_agent_for_option_plan(self, task: Task) -> list:
         """Query the agent for an option plan and parse it."""
@@ -595,60 +571,6 @@ Output ONLY the option plan lines at the end, after any analysis."""
                 )
 
         return "\n".join(lines)
-
-    def _build_learning_context(self,
-                                conversation_log: List[Dict[str, Any]]) -> str:
-        """Build a context message from the learning session's conversation log
-        so that test sessions retain knowledge from learning.
-
-        Preserves the full conversation structure including tool calls
-        and their results so the agent sees the same information it
-        would in the original session.
-        """
-        sections: List[str] = []
-        sections.append(
-            "Below is the transcript of your previous learning "
-            "interactions. Use this context to inform your planning.\n")
-
-        for i, entry in enumerate(conversation_log):
-            query = entry.get("query", "")
-            sections.append(f"=== Learning Interaction {i + 1} ===")
-            sections.append(f"[User]\n{query}")
-
-            for msg in entry.get("response", []):
-                msg_type = msg.get("type")
-                if msg_type == "assistant":
-                    parts: List[str] = []
-                    for block in msg.get("content", []):
-                        if not isinstance(block, dict):
-                            continue
-                        btype = block.get("type")
-                        if btype == "text":
-                            parts.append(block["text"])
-                        elif btype == "tool_use":
-                            name = block.get("name", "?")
-                            inp = block.get("input", {})
-                            parts.append(f"[Tool Call: {name}]\n{inp}")
-                    if parts:
-                        sections.append(f"[Assistant]\n" + "\n".join(parts))
-                elif msg_type == "user":
-                    parts = []
-                    for block in msg.get("content", []):
-                        if not isinstance(block, dict):
-                            continue
-                        btype = block.get("type")
-                        if btype == "text":
-                            parts.append(block["text"])
-                        elif btype == "tool_result":
-                            content = block.get("content", "")
-                            is_err = block.get("is_error", False)
-                            prefix = "[Tool Error]" if is_err \
-                                else "[Tool Result]"
-                            parts.append(f"{prefix}\n{content}")
-                    if parts:
-                        sections.append("\n".join(parts))
-
-        return "\n\n".join(sections)
 
     def _extract_option_plan_text(self, responses: List[Dict[str,
                                                              Any]]) -> str:

--- a/predicators/approaches/base_approach.py
+++ b/predicators/approaches/base_approach.py
@@ -134,6 +134,19 @@ class BaseApproach(abc.ABC):
         """Reset the metrics dictionary."""
         self._metrics = defaultdict(float)
 
+    def begin_test_phase(self) -> None:
+        """Called before the test task loop begins.
+
+        Override to set up test-phase state (e.g. isolating the agent
+        session so test context doesn't leak into learning).
+        """
+
+    def end_test_phase(self) -> None:
+        """Called after the test task loop ends.
+
+        Override to tear down test-phase state.
+        """
+
 
 class BaseApproachWrapper(BaseApproach):
     """Base class for an approach that wraps another approach."""

--- a/tests/approaches/test_agent_bilevel_approach.py
+++ b/tests/approaches/test_agent_bilevel_approach.py
@@ -1,0 +1,614 @@
+"""Tests for AgentBilevelApproach — parsing and refinement logic."""
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+from gym.spaces import Box
+
+from predicators import utils
+from predicators.approaches.agent_bilevel_approach import (
+    AgentBilevelApproach, _SketchStep)
+from predicators.structs import (Action, GroundAtom, Object,
+                                 ParameterizedOption, Predicate, State, Task,
+                                 Type)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_block_type = Type("block", ["x", "y", "held"])
+_robot_type = Type("robot", ["x", "y"])
+
+_block0 = Object("block0", _block_type)
+_block1 = Object("block1", _block_type)
+_robot = Object("robot0", _robot_type)
+
+_Holding = Predicate("Holding", [_block_type],
+                      lambda s, o: s.get(o[0], "held") > 0.5)
+_On = Predicate("On", [_block_type, _block_type],
+                 lambda s, o: abs(s.get(o[0], "x") - s.get(o[1], "x")) < 0.1)
+_HandEmpty = Predicate("HandEmpty", [_robot_type],
+                        lambda s, o: True)
+
+_ALL_PREDICATES = {_Holding, _On, _HandEmpty}
+_ALL_OBJECTS = [_block0, _block1, _robot]
+
+
+def _noop_policy(s, m, o, p):
+    return Action(np.zeros(1, dtype=np.float32))
+
+
+def _always_true(s, m, o, p):
+    return True
+
+
+def _always_false(s, m, o, p):
+    return False
+
+
+_Pick = ParameterizedOption(
+    "Pick",
+    types=[_block_type],
+    params_space=Box(low=np.array([0.0], dtype=np.float32),
+                     high=np.array([1.0], dtype=np.float32)),
+    policy=_noop_policy,
+    initiable=_always_true,
+    terminal=_always_false,
+)
+
+_Place = ParameterizedOption(
+    "Place",
+    types=[_block_type, _block_type],
+    params_space=Box(low=np.array([0.0, 0.0], dtype=np.float32),
+                     high=np.array([1.0, 1.0], dtype=np.float32)),
+    policy=_noop_policy,
+    initiable=_always_true,
+    terminal=_always_false,
+)
+
+_Wait = ParameterizedOption(
+    "Wait",
+    types=[_robot_type],
+    params_space=Box(low=np.array([], dtype=np.float32),
+                     high=np.array([], dtype=np.float32)),
+    policy=_noop_policy,
+    initiable=_always_true,
+    terminal=_always_false,
+)
+
+_ALL_OPTIONS = {_Pick, _Place, _Wait}
+
+
+def _make_state(overrides=None):
+    """Create a simple state with default feature values."""
+    data = {
+        _block0: np.array([0.1, 0.2, 0.0], dtype=np.float32),
+        _block1: np.array([0.5, 0.6, 0.0], dtype=np.float32),
+        _robot: np.array([0.0, 0.0], dtype=np.float32),
+    }
+    if overrides:
+        for obj, vals in overrides.items():
+            data[obj] = np.array(vals, dtype=np.float32)
+    return State(data)
+
+
+def _make_approach():
+    """Create an AgentBilevelApproach with mock config and option model."""
+    state = _make_state()
+    goal = {GroundAtom(_On, [_block0, _block1])}
+    task = Task(state, goal)
+
+    utils.reset_config({
+        "env": "cover",
+        "approach": "agent_bilevel",
+        "num_train_tasks": 1,
+        "num_test_tasks": 1,
+        "option_model_name": "oracle",
+        "seed": 42,
+        "agent_bilevel_max_samples_per_step": 10,
+        "agent_bilevel_max_retries": 0,
+        "agent_bilevel_check_subgoals": True,
+    })
+
+    mock_option_model = MagicMock()
+    approach = AgentBilevelApproach(
+        initial_predicates=_ALL_PREDICATES,
+        initial_options=_ALL_OPTIONS,
+        types={_block_type, _robot_type},
+        action_space=Box(low=-1, high=1, shape=(1,)),
+        train_tasks=[task],
+        option_model=mock_option_model,
+    )
+    return approach, mock_option_model, task
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_subgoal_annotations
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubgoalAnnotations:
+    """Tests for plan text subgoal parsing."""
+
+    def test_basic_subgoals(self):
+        approach, _, _ = _make_approach()
+        text = (
+            "Pick(block0:block) -> {Holding(block0:block)}\n"
+            "Place(block0:block, block1:block) -> {On(block0:block, block1:block)}\n"
+        )
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 2
+        # First step: Holding(block0)
+        assert result[0] is not None
+        assert GroundAtom(_Holding, [_block0]) in result[0]
+        # Second step: On(block0, block1)
+        assert result[1] is not None
+        assert GroundAtom(_On, [_block0, _block1]) in result[1]
+
+    def test_no_subgoals(self):
+        approach, _, _ = _make_approach()
+        text = (
+            "Pick(block0:block)\n"
+            "Place(block0:block, block1:block)\n"
+        )
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 2
+        assert result[0] is None
+        assert result[1] is None
+
+    def test_mixed_subgoals(self):
+        """Some lines have subgoals, some don't."""
+        approach, _, _ = _make_approach()
+        text = (
+            "Pick(block0:block) -> {Holding(block0:block)}\n"
+            "Wait(robot0:robot)\n"
+            "Place(block0:block, block1:block) -> {On(block0:block, block1:block)}\n"
+        )
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 3
+        assert result[0] is not None
+        assert result[1] is None  # Wait has no subgoal
+        assert result[2] is not None
+
+    def test_multiple_atoms_in_subgoal(self):
+        approach, _, _ = _make_approach()
+        text = ("Place(block0:block, block1:block) "
+                "-> {On(block0:block, block1:block), HandEmpty(robot0:robot)}\n")
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 1
+        assert result[0] is not None
+        assert len(result[0]) == 2
+        assert GroundAtom(_On, [_block0, _block1]) in result[0]
+        assert GroundAtom(_HandEmpty, [_robot]) in result[0]
+
+    def test_unknown_predicate_skipped(self):
+        approach, _, _ = _make_approach()
+        text = "Pick(block0:block) -> {FakePred(block0:block)}\n"
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 1
+        assert result[0] is None  # FakePred unrecognized, no valid atoms
+
+    def test_unknown_object_skipped(self):
+        approach, _, _ = _make_approach()
+        text = "Pick(block0:block) -> {Holding(block99:block)}\n"
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 1
+        assert result[0] is None  # block99 doesn't exist
+
+    def test_arity_mismatch_skipped(self):
+        approach, _, _ = _make_approach()
+        # Holding expects 1 arg, giving 2
+        text = "Pick(block0:block) -> {Holding(block0:block, block1:block)}\n"
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 1
+        assert result[0] is None
+
+    def test_typed_object_refs_in_subgoals(self):
+        """Agent outputs obj:type in subgoal atoms — should still parse."""
+        approach, _, _ = _make_approach()
+        text = (
+            "Pick(block0:block) -> {Holding(block0:block)}\n"
+            "Place(block0:block, block1:block) "
+            "-> {On(block0:block, block1:block)}\n"
+        )
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 2
+        assert result[0] is not None
+        assert GroundAtom(_Holding, [_block0]) in result[0]
+        assert result[1] is not None
+        assert GroundAtom(_On, [_block0, _block1]) in result[1]
+
+    def test_preamble_ignored(self):
+        """Non-option lines should be ignored."""
+        approach, _, _ = _make_approach()
+        text = (
+            "Here is my analysis:\n"
+            "I think we should pick block0 first.\n"
+            "\n"
+            "Pick(block0:block) -> {Holding(block0:block)}\n"
+        )
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 1
+        assert result[0] is not None
+
+    def test_whitespace_in_atoms(self):
+        """Spaces around commas in atom arguments."""
+        approach, _, _ = _make_approach()
+        text = "Place(block0:block, block1:block) -> { On( block0:block , block1:block ) }\n"
+        result = approach._parse_subgoal_annotations(
+            text, _ALL_PREDICATES, _ALL_OBJECTS)
+
+        assert len(result) == 1
+        assert result[0] is not None
+        assert GroundAtom(_On, [_block0, _block1]) in result[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _refine_sketch
+# ---------------------------------------------------------------------------
+
+
+class TestRefineSketch:
+    """Tests for backtracking refinement search."""
+
+    def test_empty_sketch(self):
+        approach, _, task = _make_approach()
+        plan, success = approach._refine_sketch(task, [], timeout=5.0)
+        assert plan == []
+        assert success is False
+
+    def test_single_step_no_params(self):
+        """Option with empty params_space — should succeed in 1 try."""
+        approach, mock_om, task = _make_approach()
+
+        # Option model: Wait always succeeds, goal holds after
+        goal_state = _make_state({_block0: [0.5, 0.6, 0.0]})
+        mock_om.get_next_state_and_num_actions.return_value = (goal_state, 5)
+
+        sketch = [_SketchStep(option=_Wait, objects=[_robot],
+                              subgoal_atoms=None)]
+        plan, success = approach._refine_sketch(task, sketch, timeout=5.0)
+
+        assert success is True
+        assert len(plan) == 1
+        assert plan[0].name == "Wait"
+
+    def test_single_step_with_params_success(self):
+        """Option with params — should find working params via sampling."""
+        approach, mock_om, task = _make_approach()
+
+        goal_state = _make_state({_block0: [0.5, 0.6, 0.0]})
+        mock_om.get_next_state_and_num_actions.return_value = (goal_state, 3)
+
+        sketch = [_SketchStep(option=_Pick, objects=[_block0],
+                              subgoal_atoms=None)]
+        plan, success = approach._refine_sketch(task, sketch, timeout=5.0)
+
+        assert success is True
+        assert len(plan) == 1
+
+    def test_subgoal_check_pass(self):
+        """Subgoal atoms hold after execution."""
+        approach, mock_om, task = _make_approach()
+
+        # After Pick, Holding(block0) should hold — set held=1
+        held_state = _make_state({_block0: [0.1, 0.2, 1.0]})
+        # After Place, On(block0, block1) — set x close
+        goal_state = _make_state({_block0: [0.5, 0.6, 0.0]})
+
+        mock_om.get_next_state_and_num_actions.side_effect = [
+            (held_state, 3),
+            (goal_state, 3),
+        ]
+
+        sketch = [
+            _SketchStep(option=_Pick, objects=[_block0],
+                        subgoal_atoms={GroundAtom(_Holding, [_block0])}),
+            _SketchStep(option=_Place, objects=[_block0, _block1],
+                        subgoal_atoms={GroundAtom(_On,
+                                                  [_block0, _block1])}),
+        ]
+        plan, success = approach._refine_sketch(task, sketch, timeout=5.0)
+
+        assert success is True
+        assert len(plan) == 2
+
+    def test_subgoal_check_fail_triggers_resample(self):
+        """Subgoal atoms don't hold — should resample params."""
+        approach, mock_om, task = _make_approach()
+
+        # Holding never holds (held=0) — subgoal always fails
+        bad_state = _make_state({_block0: [0.1, 0.2, 0.0]})
+        mock_om.get_next_state_and_num_actions.return_value = (bad_state, 3)
+
+        sketch = [
+            _SketchStep(option=_Pick, objects=[_block0],
+                        subgoal_atoms={GroundAtom(_Holding, [_block0])}),
+        ]
+        plan, success = approach._refine_sketch(task, sketch, timeout=5.0)
+
+        # Should exhaust all samples and fail
+        assert success is False
+        # Option model called max_samples times (10)
+        assert mock_om.get_next_state_and_num_actions.call_count == 10
+
+    def test_backtracking_across_steps(self):
+        """Step 2 fails, causing step 1 to be re-sampled."""
+        approach, mock_om, task = _make_approach()
+        utils.reset_config({
+            "env": "cover",
+            "approach": "agent_bilevel",
+            "num_train_tasks": 1,
+            "num_test_tasks": 1,
+            "seed": 42,
+            "agent_bilevel_max_samples_per_step": 3,
+            "agent_bilevel_max_retries": 0,
+            "agent_bilevel_check_subgoals": False,
+        })
+
+        call_count = 0
+        goal_state = _make_state({_block0: [0.5, 0.6, 0.0]})
+        noop_state = _make_state()
+
+        def side_effect(state, option):
+            nonlocal call_count
+            call_count += 1
+            if option.name == "Pick":
+                return (noop_state, 3)  # Pick always succeeds
+            # Place: succeed only on the last attempt
+            if call_count >= 8:
+                return (goal_state, 3)
+            return (noop_state, 0)  # fail (noop)
+
+        mock_om.get_next_state_and_num_actions.side_effect = side_effect
+
+        sketch = [
+            _SketchStep(option=_Pick, objects=[_block0], subgoal_atoms=None),
+            _SketchStep(option=_Place, objects=[_block0, _block1],
+                        subgoal_atoms=None),
+        ]
+        plan, success = approach._refine_sketch(task, sketch, timeout=10.0)
+
+        # Should have backtracked and eventually succeeded
+        assert success is True
+        assert len(plan) == 2
+        assert call_count >= 4  # at least one backtrack cycle
+
+    def test_not_initiable_triggers_resample(self):
+        """Option not initiable in current state — resample."""
+        approach, mock_om, task = _make_approach()
+        utils.reset_config({
+            "env": "cover",
+            "approach": "agent_bilevel",
+            "num_train_tasks": 1,
+            "num_test_tasks": 1,
+            "seed": 42,
+            "agent_bilevel_max_samples_per_step": 3,
+        })
+
+        # Create an option that is never initiable
+        not_initiable = ParameterizedOption(
+            "Pick",
+            types=[_block_type],
+            params_space=Box(low=np.array([0.0], dtype=np.float32),
+                             high=np.array([1.0], dtype=np.float32)),
+            policy=_noop_policy,
+            initiable=_always_false,
+            terminal=_always_false,
+        )
+
+        sketch = [_SketchStep(option=not_initiable, objects=[_block0],
+                              subgoal_atoms=None)]
+        plan, success = approach._refine_sketch(task, sketch, timeout=5.0)
+
+        assert success is False
+        # Option model never called since initiable is always False
+        mock_om.get_next_state_and_num_actions.assert_not_called()
+
+    def test_goal_check_on_final_step(self):
+        """Final step must satisfy the task goal even without subgoals."""
+        approach, mock_om, task = _make_approach()
+        utils.reset_config({
+            "env": "cover",
+            "approach": "agent_bilevel",
+            "num_train_tasks": 1,
+            "num_test_tasks": 1,
+            "seed": 42,
+            "agent_bilevel_max_samples_per_step": 5,
+            "agent_bilevel_check_subgoals": False,
+        })
+
+        # State that doesn't satisfy goal On(block0, block1)
+        bad_state = _make_state({_block0: [0.9, 0.2, 0.0]})
+        mock_om.get_next_state_and_num_actions.return_value = (bad_state, 3)
+
+        sketch = [_SketchStep(option=_Pick, objects=[_block0],
+                              subgoal_atoms=None)]
+        plan, success = approach._refine_sketch(task, sketch, timeout=5.0)
+
+        # Goal never holds → exhausts samples
+        assert success is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: _query_agent_for_plan_sketch (with mocked agent)
+# ---------------------------------------------------------------------------
+
+
+class TestQueryAgentForPlanSketch:
+    """Tests for end-to-end sketch extraction from mock agent responses."""
+
+    def _mock_responses(self, plan_text):
+        """Build mock agent response list containing plan_text."""
+        return [
+            {
+                "type": "assistant",
+                "content": [{"type": "text", "text": plan_text}],
+            },
+        ]
+
+    def test_basic_sketch_extraction(self):
+        approach, _, task = _make_approach()
+
+        plan_text = (
+            "Pick(block0:block) -> {Holding(block0:block)}\n"
+            "Place(block0:block, block1:block) -> {On(block0:block, block1:block)}\n"
+        )
+
+        with patch.object(approach, '_query_agent_sync',
+                          return_value=self._mock_responses(plan_text)):
+            sketch = approach._query_agent_for_plan_sketch(task)
+
+        assert len(sketch) == 2
+        assert sketch[0].option.name == "Pick"
+        assert list(sketch[0].objects) == [_block0]
+        assert sketch[0].subgoal_atoms is not None
+        assert GroundAtom(_Holding, [_block0]) in sketch[0].subgoal_atoms
+
+        assert sketch[1].option.name == "Place"
+        assert list(sketch[1].objects) == [_block0, _block1]
+        assert sketch[1].subgoal_atoms is not None
+
+    def test_sketch_without_subgoals(self):
+        approach, _, task = _make_approach()
+
+        plan_text = (
+            "Pick(block0:block)\n"
+            "Place(block0:block, block1:block)\n"
+        )
+
+        with patch.object(approach, '_query_agent_sync',
+                          return_value=self._mock_responses(plan_text)):
+            sketch = approach._query_agent_for_plan_sketch(task)
+
+        assert len(sketch) == 2
+        assert sketch[0].subgoal_atoms is None
+        assert sketch[1].subgoal_atoms is None
+
+    def test_sketch_with_code_fences(self):
+        approach, _, task = _make_approach()
+
+        plan_text = (
+            "Here is the plan:\n"
+            "```\n"
+            "Pick(block0:block) -> {Holding(block0:block)}\n"
+            "Place(block0:block, block1:block)\n"
+            "```\n"
+        )
+
+        with patch.object(approach, '_query_agent_sync',
+                          return_value=self._mock_responses(plan_text)):
+            sketch = approach._query_agent_for_plan_sketch(task)
+
+        assert len(sketch) == 2
+
+    def test_sketch_with_preamble(self):
+        """Agent includes analysis text before the plan."""
+        approach, _, task = _make_approach()
+
+        plan_text = (
+            "After inspecting the environment, I found block0 and block1.\n"
+            "The goal is to place block0 on block1.\n"
+            "\n"
+            "Pick(block0:block)\n"
+            "Place(block0:block, block1:block)\n"
+        )
+
+        with patch.object(approach, '_query_agent_sync',
+                          return_value=self._mock_responses(plan_text)):
+            sketch = approach._query_agent_for_plan_sketch(task)
+
+        assert len(sketch) == 2
+
+    def test_sketch_with_wait(self):
+        approach, _, task = _make_approach()
+
+        plan_text = (
+            "Pick(block0:block) -> {Holding(block0:block)}\n"
+            "Wait(robot0:robot)\n"
+            "Place(block0:block, block1:block) -> {On(block0:block, block1:block)}\n"
+        )
+
+        with patch.object(approach, '_query_agent_sync',
+                          return_value=self._mock_responses(plan_text)):
+            sketch = approach._query_agent_for_plan_sketch(task)
+
+        assert len(sketch) == 3
+        assert sketch[0].option.name == "Pick"
+        assert sketch[1].option.name == "Wait"
+        assert sketch[1].subgoal_atoms is None
+        assert sketch[2].option.name == "Place"
+
+    def test_empty_response_raises(self):
+        """Agent returns no text → ApproachFailure."""
+        from predicators.approaches import ApproachFailure
+        approach, _, task = _make_approach()
+
+        with patch.object(approach, '_query_agent_sync',
+                          return_value=[{"type": "result", "content": []}]):
+            with pytest.raises(ApproachFailure, match="empty plan text"):
+                approach._query_agent_for_plan_sketch(task)
+
+    def test_no_valid_options_raises(self):
+        """Agent returns text with no valid option names → ApproachFailure."""
+        from predicators.approaches import ApproachFailure
+        approach, _, task = _make_approach()
+
+        plan_text = "I don't know what to do.\nSorry!\n"
+
+        with patch.object(approach, '_query_agent_sync',
+                          return_value=self._mock_responses(plan_text)):
+            with pytest.raises(ApproachFailure, match="Parsed empty"):
+                approach._query_agent_for_plan_sketch(task)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _sample_params
+# ---------------------------------------------------------------------------
+
+
+class TestSampleParams:
+
+    def test_empty_params_space(self):
+        approach, _, _ = _make_approach()
+        rng = np.random.default_rng(0)
+        params = approach._sample_params(_Wait, _make_state(), rng)
+        assert params.shape == (0,)
+        assert params.dtype == np.float32
+
+    def test_params_within_bounds(self):
+        approach, _, _ = _make_approach()
+        rng = np.random.default_rng(0)
+        for _ in range(100):
+            params = approach._sample_params(_Place, _make_state(), rng)
+            assert params.shape == (2,)
+            assert np.all(params >= 0.0)
+            assert np.all(params <= 1.0)
+            assert params.dtype == np.float32
+
+
+# ---------------------------------------------------------------------------
+# Tests: class metadata
+# ---------------------------------------------------------------------------
+
+
+def test_get_name():
+    assert AgentBilevelApproach.get_name() == "agent_bilevel"


### PR DESCRIPTION
## Summary
- New `agent_bilevel` approach using plan sketch + backtracking refinement for bilevel planning
- Refactored common logic out of `agent_planner_approach.py`
- Added `forward_check_option_model` to `base_approach.py`
- Comprehensive tests in `test_agent_bilevel_approach.py`

## Test plan
- [ ] Run `test_agent_bilevel_approach.py`
- [ ] Verify existing agent_planner tests still pass