### PR TITLE
Unify backtracking refinement into shared function

### DIFF
--- a/predicators/approaches/agent_bilevel_approach.py
+++ b/predicators/approaches/agent_bilevel_approach.py
@@ -574,87 +574,38 @@ Output ONLY the plan sketch lines at the end, after any analysis."""
         Returns True if the plan reaches the goal, False otherwise.
         """
         state = task.init
-        option_names = cast(  # pylint: disable=protected-access
-            Any, self._option_model)._name_to_parameterized_option
         predicates = self._get_all_predicates()
         total_actions = 0
 
         for i, grounded in enumerate(plan):
-            # Create a fresh option copy (same as the option model does).
-            env_param_opt = option_names.get(grounded.parent.name,
-                                             grounded.parent)
-            option_copy = env_param_opt.ground(grounded.objects,
-                                               grounded.params.copy())
-            # Propagate Wait target atoms through re-grounding
-            for key in ("wait_target_atoms", "wait_target_neg_atoms"):
-                if key in grounded.memory:
-                    option_copy.memory[key] = grounded.memory[key]
-
-            if not option_copy.initiable(state):
+            if not grounded.initiable(state):
                 logging.info(f"Forward validation: step {i} "
-                             f"({option_copy.name}) not initiable.")
-                return False
-
-            # Build a terminal condition that mirrors the option model:
-            # 1. The option's own terminal
-            # 2. terminate_on_repeat (stuck detection)
-            # 3. wait_option_terminate_on_atom_change
-            last_state_ref: List[Optional[State]] = [None]
-            abstract_fn = lambda s, _p=predicates: utils.abstract(s, _p)
-
-            def _terminal(  # pylint: disable=cell-var-from-loop
-                    s: State,
-                    oc: _Option = option_copy,
-                    _abs: Callable = abstract_fn) -> bool:
-                if oc.terminal(s):
-                    return True
-                prev = last_state_ref[0]
-                if prev is not None:
-                    if (CFG.option_model_terminate_on_repeat
-                            and prev.allclose(s)):
-                        raise utils.OptionExecutionFailure(
-                            f"Option '{oc.name}' got stuck.")
-                    if (CFG.wait_option_terminate_on_atom_change
-                            and oc.name == "Wait"):
-                        result = utils.check_wait_target_atoms(oc, s, _abs)
-                        if result is True:
-                            last_state_ref[0] = s
-                            return True
-                        if result is None:
-                            cur_atoms = _abs(s)
-                            prev_atoms = _abs(prev)
-                            if cur_atoms != prev_atoms:
-                                last_state_ref[0] = s
-                                return True
-                last_state_ref[0] = s
+                             f"({grounded.name}) not initiable.")
                 return False
 
             try:
-                sim = cast(  # pylint: disable=protected-access
-                    Any, self._option_model)._simulator
-                traj = utils.run_policy_with_simulator(
-                    option_copy.policy,
-                    sim,
-                    state,
-                    _terminal,
-                    max_num_steps=CFG.max_num_steps_option_rollout)
-            except (utils.OptionExecutionFailure,
-                    utils.EnvironmentFailure) as e:
+                next_state, num_actions = \
+                    self._option_model.get_next_state_and_num_actions(
+                        state, grounded)
+            except utils.EnvironmentFailure as e:
                 logging.info(f"Forward validation: step {i} "
-                             f"({option_copy.name}) failed: {e}")
+                             f"({grounded.name}) failed: {e}")
                 return False
 
-            if len(traj.actions) == 0:
+            if num_actions == 0:
+                reason = cast(Any, self._option_model) \
+                    .last_execution_failure or \
+                    "produced 0 actions"
                 logging.info(f"Forward validation: step {i} "
-                             f"({option_copy.name}) produced 0 actions.")
+                             f"({grounded.name}) failed: {reason}")
                 return False
 
-            total_actions += len(traj.actions)
-            state = traj.states[-1]
+            total_actions += num_actions
+            state = next_state
             atoms = utils.abstract(state, predicates)
             logging.debug(
                 f"Forward validation: step {i} "
-                f"({option_copy.name}) OK, {len(traj.actions)} actions. "
+                f"({grounded.name}) OK, {num_actions} actions. "
                 f"Atoms: {sorted(str(a) for a in atoms)}")
 
         if not task.goal_holds(state):

--- a/predicators/approaches/agent_bilevel_approach.py
+++ b/predicators/approaches/agent_bilevel_approach.py
@@ -16,7 +16,7 @@ import dataclasses
 import logging
 import re
 import time
-from typing import Any, Callable, List, Optional, Sequence, Set, Tuple, cast
+from typing import Callable, List, Optional, Sequence, Set, Tuple, cast
 
 import numpy as np
 
@@ -501,62 +501,37 @@ Output ONLY the plan sketch lines at the end, after any analysis."""
         task: Task,
         plan: List[_Option],
     ) -> bool:
-        """Re-execute the plan continuously in the option model's env.
+        """Re-execute the plan continuously in the option model.
 
-        Unlike refinement (which resets state between steps via
-        ``_reset_state``), this runs all options sequentially so that the
-        physics state carries forward naturally — matching how the main
-        env will execute during the real episode.
+        Runs all options sequentially so that state carries forward
+        naturally — matching how the real env will execute.
 
         Returns True if the plan reaches the goal, False otherwise.
         """
-        state = task.init
-        predicates = self._get_all_predicates()
-        total_actions = 0
+        n = len(plan)
+        if n == 0:
+            return task.goal_holds(task.init)
 
-        for i, grounded in enumerate(plan):
-            if not grounded.initiable(state):
-                logging.info(f"Forward validation: step {i} "
-                             f"({grounded.name}) not initiable.")
-                return False
+        def sample_fn(i: int, _s: State, _r: np.random.Generator) -> _Option:
+            return plan[i]
 
-            try:
-                next_state, num_actions = \
-                    self._option_model.get_next_state_and_num_actions(
-                        state, grounded)
-            except utils.EnvironmentFailure as e:
-                logging.info(f"Forward validation: step {i} "
-                             f"({grounded.name}) failed: {e}")
-                return False
+        def validate_fn(i: int, _s: State, _o: _Option, post: State,
+                        _n: int) -> Tuple[bool, str]:
+            if i == n - 1 and not task.goal_holds(post):
+                return False, "goal not reached"
+            return True, ""
 
-            if num_actions == 0:
-                reason = cast(Any, self._option_model) \
-                    .last_execution_failure or \
-                    "produced 0 actions"
-                logging.info(f"Forward validation: step {i} "
-                             f"({grounded.name}) failed: {reason}")
-                return False
-
-            total_actions += num_actions
-            state = next_state
-            atoms = utils.abstract(state, predicates)
-            logging.debug(f"Forward validation: step {i} "
-                          f"({grounded.name}) OK, {num_actions} actions. "
-                          f"Atoms: {sorted(str(a) for a in atoms)}")
-
-        if not task.goal_holds(state):
-            atoms = utils.abstract(state, predicates)
-            goal_atoms = task.goal
-            missing = goal_atoms - atoms
-            logging.info(
-                f"Forward validation: goal not reached. "
-                f"Missing: {{{', '.join(str(a) for a in sorted(missing))}}}. "
-                f"State:\n{state.pretty_str()}")
-            return False
-
-        logging.info(f"Forward validation succeeded: {total_actions} "
-                     f"actions from {len(plan)} steps.")
-        return True
+        _, success, _ = run_backtracking_refinement(
+            init_state=task.init,
+            option_model=self._option_model,
+            n_steps=n,
+            max_tries=[1] * n,
+            sample_fn=sample_fn,
+            validate_fn=validate_fn,
+            rng=np.random.default_rng(0),
+            timeout=float('inf'),
+        )
+        return success
 
     # ------------------------------------------------------------------ #
     # Helpers

--- a/predicators/approaches/agent_bilevel_approach.py
+++ b/predicators/approaches/agent_bilevel_approach.py
@@ -23,6 +23,7 @@ import numpy as np
 from predicators import utils
 from predicators.approaches import ApproachFailure
 from predicators.approaches.agent_planner_approach import AgentPlannerApproach
+from predicators.planning import run_backtracking_refinement
 from predicators.settings import CFG
 from predicators.structs import Action, GroundAtom, Object, \
     ParameterizedOption, Predicate, State, Task, _Option
@@ -409,6 +410,8 @@ Output ONLY the plan sketch lines at the end, after any analysis."""
         Returns ``(plan, success)``.  On success, ``plan`` is a list of
         grounded options that achieves the task goal.  On failure,
         ``plan`` is the longest partial refinement found.
+
+        Delegates to ``run_backtracking_refinement`` for the core loop.
         """
         if not sketch:
             return [], False
@@ -416,131 +419,65 @@ Output ONLY the plan sketch lines at the end, after any analysis."""
         rng = np.random.default_rng(CFG.seed)
         max_samples = CFG.agent_bilevel_max_samples_per_step
         check_subgoals = CFG.agent_bilevel_check_subgoals
-        start_time = time.perf_counter()
-
         n = len(sketch)
-        cur_idx = 0
-        num_tries = [0] * n
         max_tries = [
             max_samples if step.option.params_space.shape[0] > 0 else 1
             for step in sketch
         ]
-        plan: List[Optional[_Option]] = [None] * n
-        traj: List[Optional[State]] = [task.init] + [None] * n
+        predicates = self._get_all_predicates()
 
-        total_samples = 0
-
-        while cur_idx < n:
-            elapsed = time.perf_counter() - start_time
-            if elapsed > timeout:
-                logging.info(
-                    f"Sketch refinement timed out after {elapsed:.1f}s "
-                    f"at step {cur_idx}/{n}, {total_samples} total samples.")
-                return [p for p in plan if p is not None], False
-
-            step = sketch[cur_idx]
-            num_tries[cur_idx] += 1
-            total_samples += 1
-            step_name = (f"{step.option.name}"
-                         f"({', '.join(o.name for o in step.objects)})")
-
-            # Optionally log state before sampling
-            cur_state = traj[cur_idx]
-            assert cur_state is not None, f"traj[{cur_idx}] should not be None"
-
+        def sample_fn(idx: int, state: State,
+                      rng_: np.random.Generator) -> _Option:
+            step = sketch[idx]
             if CFG.agent_bilevel_log_state:
+                step_name = (f"{step.option.name}"
+                             f"({', '.join(o.name for o in step.objects)})")
                 logging.debug(f"  State before {step_name}:\n"
-                              f"{cur_state.pretty_str()}")
-
-            # Sample continuous parameters and ground option
-            params = self._sample_params(step.option, cur_state, rng)
+                              f"{state.pretty_str()}")
+            params = self._sample_params(step.option, state, rng_)
             grounded = step.option.ground(step.objects, params)
-            # Inject Wait target atoms from sketch annotations
             if grounded.name == "Wait":
                 if step.subgoal_atoms is not None:
-                    grounded.memory["wait_target_atoms"] = step.subgoal_atoms
+                    grounded.memory["wait_target_atoms"] = \
+                        step.subgoal_atoms
                 if step.subgoal_neg_atoms is not None:
                     grounded.memory["wait_target_neg_atoms"] = \
                         step.subgoal_neg_atoms
-            plan[cur_idx] = grounded
+            return grounded
 
-            state = cur_state
-            can_continue = False
-            fail_reason = "not initiable"
+        def validate_fn(idx: int, _pre_state: State, _option: _Option,
+                        post_state: State,
+                        _num_actions: int) -> Tuple[bool, str]:
+            step = sketch[idx]
+            if check_subgoals and step.subgoal_atoms is not None:
+                current_atoms = utils.abstract(post_state, predicates)
+                if not step.subgoal_atoms.issubset(current_atoms):
+                    missing = step.subgoal_atoms - current_atoms
+                    return False, (f"subgoal missing: "
+                                   f"{{{', '.join(str(a) for a in missing)}}}")
+            if idx == n - 1:
+                if not task.goal_holds(post_state):
+                    return False, "goal not reached"
+            return True, ""
 
-            if grounded.initiable(state):
-                try:
-                    next_state, num_actions = \
-                        self._option_model.get_next_state_and_num_actions(
-                            state, grounded)
-                except utils.EnvironmentFailure as e:
-                    fail_reason = f"env failure: {e}"
-                else:
-                    if num_actions == 0:
-                        model = self._option_model
-                        fail_reason = (
-                            getattr(  # type: ignore[attr-defined]
-                                model, "last_execution_failure", None)
-                            or "0 actions")
-                    else:
-                        traj[cur_idx + 1] = next_state
-                        # Check subgoals if specified
-                        if (check_subgoals and step.subgoal_atoms is not None):
-                            current_atoms = utils.abstract(
-                                next_state, self._get_all_predicates())
-                            if step.subgoal_atoms.issubset(current_atoms):
-                                can_continue = True
-                            else:
-                                missing = step.subgoal_atoms - current_atoms
-                                fail_reason = (
-                                    f"subgoal missing: "
-                                    f"{{{', '.join(str(a) for a in missing)}}}"
-                                )
-                        else:
-                            can_continue = True
-                        # Final step: also check task goal
-                        if can_continue and cur_idx == n - 1:
-                            if not task.goal_holds(next_state):
-                                can_continue = False
-                                fail_reason = "goal not reached"
+        plan, success, total_samples = run_backtracking_refinement(
+            init_state=task.init,
+            option_model=self._option_model,
+            n_steps=n,
+            max_tries=max_tries,
+            sample_fn=sample_fn,
+            validate_fn=validate_fn,
+            rng=rng,
+            timeout=timeout,
+        )
 
-            if can_continue:
-                logging.info(
-                    f"  Step {cur_idx}/{n} {step_name} OK "
-                    f"(sample {num_tries[cur_idx]}/{max_tries[cur_idx]})\n")
-                if CFG.agent_bilevel_log_state:
-                    next_st = traj[cur_idx + 1]
-                    assert next_st is not None
-                    logging.debug(f"  State after {step_name}:\n"
-                                  f"{next_st.pretty_str()}")
-                cur_idx += 1
-            else:
-                logging.debug(
-                    f"  Step {cur_idx}/{n} {step_name} FAIL "
-                    f"(sample {num_tries[cur_idx]}/{max_tries[cur_idx]})"
-                    f": {fail_reason}")
-                # Backtrack: re-try current step or go back further
-                while num_tries[cur_idx] >= max_tries[cur_idx]:
-                    bt_objs = ", ".join(o.name
-                                        for o in sketch[cur_idx].objects)
-                    bt_name = (f"{sketch[cur_idx].option.name}"
-                               f"({bt_objs})")
-                    logging.info(f"  Step {cur_idx}/{n} {bt_name} exhausted "
-                                 f"{max_tries[cur_idx]} samples, backtracking")
-                    num_tries[cur_idx] = 0
-                    plan[cur_idx] = None
-                    traj[cur_idx + 1] = None
-                    cur_idx -= 1
-                    if cur_idx < 0:
-                        logging.info(f"Sketch refinement exhausted after "
-                                     f"{total_samples} total samples.")
-                        return [], False
+        logging.info(f"Refinement {'succeeded' if success else 'failed'}: "
+                     f"{total_samples} samples for {n} steps.")
 
-        # All steps succeeded
-        assert all(p is not None for p in plan)
-        logging.info(f"Refinement complete: {total_samples} total samples "
-                     f"for {n} steps.")
-        return cast(List[_Option], plan), True
+        filtered = [p for p in plan if p is not None]
+        if success:
+            return cast(List[_Option], filtered), True
+        return filtered, False
 
     def _sample_params(self, option: ParameterizedOption, _state: State,
                        rng: np.random.Generator) -> np.ndarray:
@@ -603,10 +540,9 @@ Output ONLY the plan sketch lines at the end, after any analysis."""
             total_actions += num_actions
             state = next_state
             atoms = utils.abstract(state, predicates)
-            logging.debug(
-                f"Forward validation: step {i} "
-                f"({grounded.name}) OK, {num_actions} actions. "
-                f"Atoms: {sorted(str(a) for a in atoms)}")
+            logging.debug(f"Forward validation: step {i} "
+                          f"({grounded.name}) OK, {num_actions} actions. "
+                          f"Atoms: {sorted(str(a) for a in atoms)}")
 
         if not task.goal_holds(state):
             atoms = utils.abstract(state, predicates)

--- a/predicators/planning.py
+++ b/predicators/planning.py
@@ -16,8 +16,8 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass
 from itertools import islice
-from typing import Any, Collection, Dict, FrozenSet, Iterator, List, \
-    Optional, Sequence, Set, Tuple, Union
+from typing import Any, Callable, Collection, Dict, FrozenSet, Iterator, \
+    List, Optional, Sequence, Set, Tuple, Union, cast
 
 import numpy as np
 
@@ -26,7 +26,7 @@ from predicators.option_model import _OptionModelBase
 from predicators.refinement_estimators import BaseRefinementEstimator
 from predicators.settings import CFG
 from predicators.structs import NSRT, AbstractPolicy, CausalProcess, \
-    DefaultState, DummyOption, GroundAtom, Metrics, Object, OptionSpec, \
+    DefaultState, GroundAtom, Metrics, Object, OptionSpec, \
     ParameterizedOption, Predicate, State, STRIPSOperator, Task, Type, \
     _GroundCausalProcess, _GroundNSRT, _GroundSTRIPSOperator, _Option
 from predicators.utils import EnvironmentFailure, _TaskPlanningHeuristic
@@ -506,6 +506,107 @@ def _skeleton_generator(
     raise _SkeletonSearchTimeout
 
 
+def run_backtracking_refinement(
+    init_state: State,
+    option_model: _OptionModelBase,
+    n_steps: int,
+    max_tries: List[int],
+    sample_fn: Callable[[int, State, np.random.Generator], _Option],
+    validate_fn: Callable[[int, State, _Option, State, int], Tuple[bool, str]],
+    rng: np.random.Generator,
+    timeout: float,
+    on_env_failure: Optional[Callable[[int, _Option, EnvironmentFailure],
+                                      None]] = None,
+    on_step_fail: Optional[Callable[[int, List[Optional[_Option]], str],
+                                    None]] = None,
+    on_exhausted: Optional[Callable[[List[Optional[_Option]]], None]] = None,
+    step_times: Optional[List[float]] = None,
+) -> Tuple[List[Optional[_Option]], bool, int]:
+    """Backtracking search over continuous parameters.
+
+    Core loop shared by SeSamE low-level search and agent bilevel
+    refinement.  Samples options via ``sample_fn``, executes them through
+    ``option_model``, and validates transitions via ``validate_fn``.
+    Backtracks when a step exhausts its sampling budget.
+
+    Returns ``(plan, success, total_samples)`` where plan entries are
+    ``None`` for unrefined steps.
+
+    Callbacks ``on_env_failure``, ``on_step_fail``, and ``on_exhausted``
+    may raise to abort the search (e.g. for failure propagation).
+    """
+    start_time = time.perf_counter()
+    cur_idx = 0
+    num_tries_arr = [0] * n_steps
+    plan: List[Optional[_Option]] = [None] * n_steps
+    traj: List[Optional[State]] = [init_state] + [None] * n_steps
+    total_samples = 0
+
+    while cur_idx < n_steps:
+        if time.perf_counter() - start_time > timeout:
+            logging.debug(
+                "Backtracking refinement timed out at step "
+                "%d/%d.", cur_idx, n_steps)
+            return plan, False, total_samples
+
+        attempt_start = time.perf_counter()
+        num_tries_arr[cur_idx] += 1
+        total_samples += 1
+        state = traj[cur_idx]
+        assert state is not None
+
+        option = sample_fn(cur_idx, state, rng)
+        plan[cur_idx] = option
+
+        can_continue = False
+        fail_reason = "not initiable"
+
+        if option.initiable(state):
+            try:
+                next_state, num_actions = \
+                    option_model.get_next_state_and_num_actions(
+                        state, option)
+            except EnvironmentFailure as e:
+                fail_reason = f"env failure: {e}"
+                if on_env_failure is not None:
+                    on_env_failure(cur_idx, option, e)
+            else:
+                if num_actions == 0:
+                    fail_reason = (getattr(option_model,
+                                           'last_execution_failure', None)
+                                   or "0 actions")
+                else:
+                    traj[cur_idx + 1] = next_state
+                    can_continue, fail_reason = validate_fn(
+                        cur_idx, state, option, next_state, num_actions)
+
+        if step_times is not None:
+            step_times[cur_idx] += time.perf_counter() - attempt_start
+
+        if can_continue:
+            cur_idx += 1
+        else:
+            logging.debug("  Step %d/%d FAIL (attempt %d/%d): %s", cur_idx,
+                          n_steps, num_tries_arr[cur_idx], max_tries[cur_idx],
+                          fail_reason)
+            if on_step_fail is not None:
+                on_step_fail(cur_idx, plan, fail_reason)
+            while num_tries_arr[cur_idx] >= max_tries[cur_idx]:
+                logging.debug(
+                    "  Step %d/%d exhausted %d samples, "
+                    "backtracking", cur_idx, n_steps, max_tries[cur_idx])
+                num_tries_arr[cur_idx] = 0
+                plan[cur_idx] = None
+                traj[cur_idx + 1] = None
+                cur_idx -= 1
+                if cur_idx < 0:
+                    if on_exhausted is not None:
+                        on_exhausted(plan)
+                    return plan, False, total_samples
+
+    return plan, True, total_samples
+
+
 def run_low_level_search(
     task: Task,
     option_model: _OptionModelBase,
@@ -525,182 +626,123 @@ def run_low_level_search(
     failed refinement, where the last step did not satisfy the skeleton,
     but all previous steps did. Note that there are multiple low-level
     plans in general; we return the first one found (arbitrarily).
+
+    Delegates to ``run_backtracking_refinement`` for the core loop.
     """
-    start_time = time.perf_counter()
-    rng_sampler = np.random.default_rng(seed)
+    if not skeleton:
+        return [], True
+
     assert CFG.sesame_propagate_failures in \
         {"after_exhaust", "immediately", "never"}
-    cur_idx = 0
-    num_tries = [0 for _ in skeleton]
-    # Optimization: if the params_space for the NSRT option is empty, only
-    # sample it once, because all samples are just empty (so equivalent).
+
+    rng = np.random.default_rng(seed)
+    n = len(skeleton)
     max_tries = [
         CFG.sesame_max_samples_per_step
         if nsrt.option.params_space.shape[0] > 0 else 1 for nsrt in skeleton
     ]
-    plan: List[_Option] = [DummyOption for _ in skeleton]
-    # If refinement_time list is passed, record the refinement time
-    # distributed across each step of the skeleton
+
+    # Per-step timing
     if refinement_time is not None:
         assert len(refinement_time) == 0
         for _ in skeleton:
             refinement_time.append(0)
-    # The number of actions taken by each option in the plan. This is to
-    # make sure that we do not exceed the task horizon.
-    num_actions_per_option = [0 for _ in plan]
-    traj: List[State] = [task.init] + [DefaultState for _ in skeleton]
+
+    # State captured by closures
+    discovered_failures: List[Optional[_DiscoveredFailure]] = [None] * n
     longest_failed_refinement: List[_Option] = []
-    # We'll use a maximum of one discovered failure per step, since
-    # resampling can render old discovered failures obsolete.
-    discovered_failures: List[Optional[_DiscoveredFailure]] = [
-        None for _ in skeleton
-    ]
-    plan_found = False
-    while cur_idx < len(skeleton):
-        if time.perf_counter() - start_time > timeout:
-            logging.debug("Exiting low-level search due to timeout.")
-            return longest_failed_refinement, False
-        assert num_tries[cur_idx] < max_tries[cur_idx]
-        try_start_time = time.perf_counter()
-        # Good debug point #2: if you have a skeleton that you think is
-        # reasonable, but sampling isn't working, print num_tries here to
-        # see at what step the backtracking search is getting stuck.
-        num_tries[cur_idx] += 1
-        state = traj[cur_idx]
-        nsrt = skeleton[cur_idx]
-        # Ground the NSRT's ParameterizedOption into an _Option.
-        # This invokes the NSRT's sampler.
-        option = nsrt.sample_option(state, task.goal, rng_sampler)
-        plan[cur_idx] = option
-        # Increment num_samples metric by 1
+    num_actions_per_option = [0] * n
+
+    # -- callbacks --------------------------------------------------------
+
+    def sample_fn(idx: int, state: State,
+                  rng_: np.random.Generator) -> _Option:
+        discovered_failures[idx] = None
         metrics["num_samples"] += 1
-        # Increment cur_idx. It will be decremented later on if we get stuck.
-        cur_idx += 1
-        if option.initiable(state):
-            try:
-                logging.info(f"Running option {option}")
-                next_state, num_actions = \
-                    option_model.get_next_state_and_num_actions(state, option)
-            except EnvironmentFailure as e:
-                logging.debug(f"Discovered a failure: {e}")
-                can_continue_on = False
-                # Remember only the most recent failure.
-                discovered_failures[cur_idx - 1] = _DiscoveredFailure(e, nsrt)
-            else:  # an EnvironmentFailure was not raised
-                discovered_failures[cur_idx - 1] = None
-                num_actions_per_option[cur_idx - 1] = num_actions
-                traj[cur_idx] = next_state
-                # Check if objects that were outside the scope had a change
-                # in state.
-                static_obj_changed = False
-                if CFG.sesame_check_static_object_changes:
-                    static_objs = set(state) - set(nsrt.objects)
-                    for obj in sorted(static_objs):
-                        if not np.allclose(
-                                traj[cur_idx][obj],
-                                traj[cur_idx - 1][obj],
-                                atol=CFG.sesame_static_object_change_tol):
-                            static_obj_changed = True
-                            break
-                if static_obj_changed:
-                    logging.debug("Cannot continue: static object changed.")
-                    can_continue_on = False
-                # Check if we have exceeded the horizon in total.
-                elif np.sum(num_actions_per_option[:cur_idx]) > max_horizon:
-                    logging.debug("Cannot continue: exceeded total horizon.")
-                    can_continue_on = False
-                # Check if we have exceeded the horizon individually.
-                elif num_actions >= CFG.max_num_steps_option_rollout:
-                    logging.debug("Cannot continue: exceeded individual "
-                                  "horizon.")
-                    can_continue_on = False
-                # Check if the option was effectively a noop.
-                elif num_actions == 0:
-                    logging.debug("Cannot continue: an noop")
-                    can_continue_on = False
-                elif CFG.sesame_check_expected_atoms:
-                    # Check atoms against expected atoms_sequence constraint.
-                    assert len(traj) == len(atoms_sequence)
-                    # The expected atoms are ones that we definitely expect to
-                    # be true at this point in the plan. They are not *all* the
-                    # atoms that could be true.
-                    expected_atoms = {
-                        atom
-                        for atom in atoms_sequence[cur_idx]
-                        if atom.predicate.name != _NOT_CAUSES_FAILURE
-                    }
-                    # This "if all" statement is equivalent to, but faster
-                    # than, checking whether expected_atoms is a subset of
-                    # utils.abstract(traj[cur_idx], predicates).
-                    if all(a.holds(traj[cur_idx]) for a in expected_atoms):
-                        can_continue_on = True
-                        if cur_idx == len(skeleton):
-                            plan_found = True
-                    else:
-                        logging.debug("Cannot continue: expected atoms not "
-                                      "hold.")
-                        can_continue_on = False
-                else:
-                    # If we're not checking expected_atoms, we need to
-                    # explicitly check the goal on the final timestep.
-                    can_continue_on = True
-                    if cur_idx == len(skeleton):
-                        if task.goal_holds(traj[cur_idx]):
-                            plan_found = True
-                        else:
-                            can_continue_on = False
-        else:
-            # The option is not initiable.
-            logging.debug("Cannot continue: option not initiable.")
-            can_continue_on = False
-        if refinement_time is not None:
-            try_end_time = time.perf_counter()
-            refinement_time[cur_idx - 1] += try_end_time - try_start_time
-        if plan_found:
-            return plan, True  # success!
-        if not can_continue_on:  # we got stuck, time to resample / backtrack!
-            # Update the longest_failed_refinement found so far.
-            if cur_idx > len(longest_failed_refinement):
-                longest_failed_refinement = list(plan[:cur_idx])
-            # If we're immediately propagating failures, and we got a failure,
-            # raise it now. We don't do this right after catching the
-            # EnvironmentFailure because we want to make sure to update
-            # the longest_failed_refinement first.
-            possible_failure = discovered_failures[cur_idx - 1]
-            if possible_failure is not None and \
+        option = skeleton[idx].sample_option(state, task.goal, rng_)
+        logging.info(f"Running option {option}")
+        return option
+
+    def validate_fn(idx: int, pre_state: State, _option: _Option,
+                    post_state: State, num_actions: int) -> Tuple[bool, str]:
+        num_actions_per_option[idx] = num_actions
+        nsrt = skeleton[idx]
+        # Static object change check.
+        if CFG.sesame_check_static_object_changes:
+            static_objs = set(pre_state) - set(nsrt.objects)
+            for obj in sorted(static_objs):
+                if not np.allclose(post_state[obj],
+                                   pre_state[obj],
+                                   atol=CFG.sesame_static_object_change_tol):
+                    return False, "static object changed"
+        # Horizon checks.
+        total_actions = sum(num_actions_per_option[:idx]) + num_actions
+        if total_actions > max_horizon:
+            return False, "exceeded total horizon"
+        if num_actions >= CFG.max_num_steps_option_rollout:
+            return False, "exceeded individual horizon"
+        # Expected-atoms check.
+        if CFG.sesame_check_expected_atoms:
+            expected_atoms = {
+                atom
+                for atom in atoms_sequence[idx + 1]
+                if atom.predicate.name != _NOT_CAUSES_FAILURE
+            }
+            if all(a.holds(post_state) for a in expected_atoms):
+                return True, ""
+            return False, "expected atoms not hold"
+        # No atoms check — verify goal on final step.
+        if idx == n - 1:
+            if not task.goal_holds(post_state):
+                return False, "goal not reached"
+        return True, ""
+
+    def on_env_failure(idx: int, _option: _Option,
+                       e: EnvironmentFailure) -> None:
+        logging.debug(f"Discovered a failure: {e}")
+        discovered_failures[idx] = _DiscoveredFailure(e, skeleton[idx])
+
+    def on_step_fail(idx: int, plan: List[Optional[_Option]],
+                     _reason: str) -> None:
+        nonlocal longest_failed_refinement
+        partial = [p for p in plan[:idx + 1] if p is not None]
+        if len(partial) > len(longest_failed_refinement):
+            longest_failed_refinement = list(partial)
+        pf = discovered_failures[idx]
+        if pf is not None and \
                 CFG.sesame_propagate_failures == "immediately":
+            raise _DiscoveredFailureException(
+                "Discovered a failure", pf,
+                {"longest_failed_refinement": longest_failed_refinement})
+
+    def on_exhausted(_plan: List[Optional[_Option]]) -> None:
+        for pf in discovered_failures:
+            if pf is not None and \
+                    CFG.sesame_propagate_failures == "after_exhaust":
                 raise _DiscoveredFailureException(
-                    "Discovered a failure", possible_failure,
+                    "Discovered a failure", pf,
                     {"longest_failed_refinement": longest_failed_refinement})
-            # Decrement cur_idx to re-do the step we just did. If num_tries
-            # is exhausted, backtrack.
-            cur_idx -= 1
-            assert cur_idx >= 0
-            while num_tries[cur_idx] == max_tries[cur_idx]:
-                num_tries[cur_idx] = 0
-                plan[cur_idx] = DummyOption
-                num_actions_per_option[cur_idx] = 0
-                traj[cur_idx + 1] = DefaultState
-                cur_idx -= 1
-                if cur_idx < 0:
-                    # Backtracking exhausted. If we're only propagating failures
-                    # after exhaustion, and if there are any failures,
-                    # propagate up the EARLIEST one so that high-level search
-                    # restarts. Otherwise, return a partial refinement so that
-                    # high-level search continues.
-                    for possible_failure in discovered_failures:
-                        if possible_failure is not None and \
-                            CFG.sesame_propagate_failures == "after_exhaust":
-                            raise _DiscoveredFailureException(
-                                "Discovered a failure", possible_failure, {
-                                    "longest_failed_refinement":
-                                    longest_failed_refinement
-                                })
-                    return longest_failed_refinement, False
-        logging.debug("Option succeed!")
-    # Should only get here if the skeleton was empty.
-    assert not skeleton
-    return [], True
+
+    # -- run --------------------------------------------------------------
+
+    plan, success, _ = run_backtracking_refinement(
+        init_state=task.init,
+        option_model=option_model,
+        n_steps=n,
+        max_tries=max_tries,
+        sample_fn=sample_fn,
+        validate_fn=validate_fn,
+        rng=rng,
+        timeout=timeout,
+        on_env_failure=on_env_failure,
+        on_step_fail=on_step_fail,
+        on_exhausted=on_exhausted,
+        step_times=refinement_time,
+    )
+
+    if success:
+        return [cast(_Option, p) for p in plan], True
+    return longest_failed_refinement, False
 
 
 def _update_nsrts_with_failure(


### PR DESCRIPTION
## Summary
- Extract duplicated backtracking search loop from `run_low_level_search` (SeSamE) and `_refine_sketch` (agent bilevel) into a single `run_backtracking_refinement` function in `planning.py`
- Both callers now delegate to it with their own `sample_fn` and `validate_fn` callbacks, eliminating ~80 lines of duplicated loop/backtracking logic
- No interface changes to `run_low_level_search` — all existing callers work without modification

## Test plan
- [x] `mypy` passes on both changed files
- [x] `pylint` passes on both changed files
- [x] All 13 `test_planning.py` tests pass
- [x] All 211 approach tests pass (including bilevel planning, pg3, oracle)