### PR TITLE
Rebrand MARA RoboSim to RoboDisco (Robot Model Discovery Benchmark)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ logs*
 saved_approaches
 saved_datasets
 scripts/results
-scripts/mara_robosim_getting_started_output/
+scripts/robodisco_getting_started_output/
 pretrained_model_cache*
 tests/datasets/mock_vlm_datasets/cache/
 machines.txt

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Methods for predicate learning are implemented as Approaches (e.g., `predicators
 
 A simple implementation of search-then-sample bilevel planning is provided in `predicators/planning.py`. This implementation uses the "SeSamE" strategy: SEarch-and-SAMple planning, then Execution.
 
-## MARA RoboSim
-Predicators ships **MARA RoboSim**, a collection of PyBullet manipulation environments exposed through a standard [Gymnasium](https://gymnasium.farama.org/) API and suitable for world-model learning, causal discovery, and RL research independent of the planning framework. See [`predicators/envs/README.md`](predicators/envs/README.md) for the env list, install instructions, quick-start code, standalone API, and getting-started notebook.
+## RoboDisco
+Predicators ships **RoboDisco** (Robot Model Discovery Benchmark), a collection of PyBullet manipulation environments exposed through a standard [Gymnasium](https://gymnasium.farama.org/) API and suitable for world-model learning, causal discovery, and RL research independent of the planning framework. See [`predicators/envs/README.md`](predicators/envs/README.md) for the env list, install instructions, quick-start code, standalone API, and getting-started notebook.
 
 ## Installation
 * This repository uses Python versions 3.10-3.11. We recommend 3.10.14.

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -4,10 +4,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Getting Started with MARA RoboSim\n",
+    "# Getting Started with RoboDisco\n",
     "\n",
-    "This notebook walks through MARA RoboSim, the PyBullet manipulation\n",
-    "suite shipped with [predicators](https://github.com/Learning-and-Intelligent-Systems/predicators):\n",
+    "This notebook walks through RoboDisco (Robot Model Discovery\n",
+    "Benchmark), the PyBullet manipulation suite shipped with\n",
+    "[predicators](https://github.com/Learning-and-Intelligent-Systems/predicators):\n",
     "discovering available environments, creating one, taking actions,\n",
     "and rendering a video — all through the standard Gymnasium API."
    ]
@@ -24,7 +25,7 @@
     "pip install -e .\n",
     "```\n",
     "\n",
-    "This installs the agent solvers and MARA RoboSim together. See\n",
+    "This installs the agent solvers and RoboDisco together. See\n",
     "[`predicators/envs/README.md`](../predicators/envs/README.md) for\n",
     "more details."
    ]
@@ -43,9 +44,9 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from predicators import utils\n",
-    "from predicators.envs import gymnasium_wrapper as mara_robosim\n",
+    "from predicators.envs import gymnasium_wrapper as robodisco\n",
     "\n",
-    "# MARA RoboSim envs read configuration from predicators.settings.CFG.\n",
+    "# RoboDisco envs read configuration from predicators.settings.CFG.\n",
     "# `reset_config` applies parser defaults so we can use the envs as a\n",
     "# library without going through main.py's command-line interface.\n",
     "utils.reset_config({\"num_train_tasks\": 1, \"num_test_tasks\": 1})"
@@ -57,7 +58,7 @@
    "source": [
     "## Discovering Available Environments\n",
     "\n",
-    "MARA RoboSim provides 15 PyBullet-based robotic manipulation environments.\n",
+    "RoboDisco provides 15 PyBullet-based robotic manipulation environments.\n",
     "Let's register them all and see what's available."
    ]
   },
@@ -67,9 +68,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mara_robosim.register_all_environments()\n",
+    "robodisco.register_all_environments()\n",
     "\n",
-    "env_ids = sorted(mara_robosim.get_all_env_ids())\n",
+    "env_ids = sorted(robodisco.get_all_env_ids())\n",
     "print(f\"{len(env_ids)} environments available:\\n\")\n",
     "for eid in env_ids:\n",
     "    print(f\"  {eid}\")"
@@ -81,7 +82,7 @@
    "source": [
     "## Creating an Environment\n",
     "\n",
-    "We'll use `mara/Blocks-v0`, an environment where a Fetch robot\n",
+    "We'll use `robodisco/Blocks-v0`, an environment where a Fetch robot\n",
     "must stack and arrange blocks on a tabletop."
    ]
   },
@@ -91,14 +92,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env = mara_robosim.make(\"mara/Blocks-v0\", render_mode=\"rgb_array\")\n",
+    "env = robodisco.make(\"robodisco/Blocks-v0\", render_mode=\"rgb_array\")\n",
     "obs, info = env.reset()\n",
     "\n",
     "frame = env.render()\n",
     "if frame is not None:\n",
     "    plt.imshow(frame)\n",
     "    plt.axis(\"off\")\n",
-    "    plt.title(\"mara/Blocks-v0\")\n",
+    "    plt.title(\"robodisco/Blocks-v0\")\n",
     "    plt.show()\n",
     "else:\n",
     "    print(\"(rendering not available in this configuration)\")"
@@ -110,7 +111,7 @@
    "source": [
     "## Exploring the Observation and Action Spaces\n",
     "\n",
-    "MARA RoboSim environments follow the Gymnasium API. Observations and\n",
+    "RoboDisco environments follow the Gymnasium API. Observations and\n",
     "actions are continuous-valued numpy arrays."
    ]
   },

--- a/predicators/envs/README.md
+++ b/predicators/envs/README.md
@@ -1,9 +1,11 @@
 # PyBullet Environments
 
-**MARA RoboSim** — a robotic world-model learning and causal-discovery
-suite. The envs ship as part of the [predicators](../../README.md)
-repository and are exposed through a standard
-[Gymnasium](https://gymnasium.farama.org/) API.
+**RoboDisco** (Robot Model Discovery Benchmark) — a robotic
+world-model learning and causal-discovery suite. The envs ship as part
+of the [predicators](../../README.md) repository and are exposed
+through a standard [Gymnasium](https://gymnasium.farama.org/) API.
+
+🌐 **Project page:** <https://yichao-liang.github.io/robodisco-site/>
 
 Each environment features a Fetch or Panda robot interacting with objects
 on a tabletop. The same envs are used by predicators' planning research
@@ -17,22 +19,22 @@ From the repo root:
 pip install -e .
 ```
 
-This installs the agent solvers and the MARA RoboSim envs together.
-The package is slightly heavy because it bundles both — a lighter
+This installs the agent solvers and the RoboDisco envs together. The
+package is slightly heavy because it bundles both — a lighter
 envs-only install is future work.
 
 ## Quick Start (Gymnasium API)
 
 ```python
 from predicators import utils
-from predicators.envs import gymnasium_wrapper as mara_robosim
+from predicators.envs import gymnasium_wrapper as robodisco
 
 # Apply parser defaults to predicators' global CFG (only needed when
 # consuming the envs as a library rather than via main.py).
 utils.reset_config({"num_train_tasks": 1, "num_test_tasks": 1})
 
-mara_robosim.register_all_environments()
-env = mara_robosim.make("mara/Blocks-v0", render_mode="rgb_array")
+robodisco.register_all_environments()
+env = robodisco.make("robodisco/Blocks-v0", render_mode="rgb_array")
 
 obs, info = env.reset()
 for _ in range(50):
@@ -62,7 +64,7 @@ The Gymnasium wrapper exposes:
 
 - **Notebook:** [`notebooks/getting_started.ipynb`](../../notebooks/getting_started.ipynb)
   — interactive walkthrough with rendering.
-- **Smoke script:** [`scripts/mara_robosim_getting_started.py`](../../scripts/mara_robosim_getting_started.py)
+- **Smoke script:** [`scripts/robodisco_getting_started.py`](../../scripts/robodisco_getting_started.py)
   — non-interactive smoke test that mirrors the notebook and resets every
   env to verify installation health.
 
@@ -75,35 +77,35 @@ Status legend:
 
 | Environment | Preview | Description | Tasks | Skills | Demos |
 |---|---|---|:---:|:---:|:---:|
-| `mara/Ants-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_ants.gif) | Place food items near ants on a tabletop | ❌ | ✅ | ❌ |
-| `mara/Balance-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_balance.gif) | Balance blocks on a beam by pressing buttons | ✅ | ✅ | ❌ |
-| `mara/Barrier-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_barrier.gif) | Move blocks past barriers to target locations | ❌ | ❌ | ❌ |
-| `mara/Blocks-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_blocks.gif) | Stack and arrange blocks on a table | ✅ | ✅ | ✅ |
-| `mara/Boil-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_boil.gif) | Fill and boil water using a jug, faucet, and burner | ✅ | ✅ | ✅ |
-| `mara/Circuit-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_circuit.gif) | Assemble circuit components (batteries, wires, switch) | ❌ | ✅ | ✅ |
-| `mara/Coffee-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_coffee.gif) | Operate a coffee machine: plug in, brew, pour, serve | ✅ | ✅ | ❌ |
-| `mara/Cover-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_cover.gif) | Place blocks to cover target regions | ✅ | ✅ | ✅ |
-| `mara/Domino-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_domino.gif) | Set up domino chains with fans, balls, and ramps | ✅ | ✅ | ✅ |
-| `mara/Fan-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_fan.gif) | Use fans to blow lightweight objects to goals | ✅ | ✅ | ✅ |
-| `mara/Float-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_float.gif) | Float light blocks by filling a container with water | ❌ | ✅ | ✅ |
-| `mara/Grow-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_grow.gif) | Grow plants by watering them | ✅ | ✅ | ✅ |
-| `mara/Laser-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_laser.gif) | Align lasers and mirrors to hit targets | ❌ | ✅ | ❌ |
-| `mara/MagicBin-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_magic_bin.gif) | Sort objects into magic bins that transform them | ❌ | ❌ | ❌ |
-| `mara/Switch-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_switch.gif) | Toggle switches to open doors and move objects | ❌ | ❌ | ❌ |
+| `robodisco/Ants-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_ants.gif) | Place food items near ants on a tabletop | ❌ | ✅ | ❌ |
+| `robodisco/Balance-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_balance.gif) | Balance blocks on a beam by pressing buttons | ✅ | ✅ | ❌ |
+| `robodisco/Barrier-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_barrier.gif) | Move blocks past barriers to target locations | ❌ | ❌ | ❌ |
+| `robodisco/Blocks-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_blocks.gif) | Stack and arrange blocks on a table | ✅ | ✅ | ✅ |
+| `robodisco/Boil-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_boil.gif) | Fill and boil water using a jug, faucet, and burner | ✅ | ✅ | ✅ |
+| `robodisco/Circuit-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_circuit.gif) | Assemble circuit components (batteries, wires, switch) | ❌ | ✅ | ✅ |
+| `robodisco/Coffee-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_coffee.gif) | Operate a coffee machine: plug in, brew, pour, serve | ✅ | ✅ | ❌ |
+| `robodisco/Cover-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_cover.gif) | Place blocks to cover target regions | ✅ | ✅ | ✅ |
+| `robodisco/Domino-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_domino.gif) | Set up domino chains with fans, balls, and ramps | ✅ | ✅ | ✅ |
+| `robodisco/Fan-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_fan.gif) | Use fans to blow lightweight objects to goals | ✅ | ✅ | ✅ |
+| `robodisco/Float-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_float.gif) | Float light blocks by filling a container with water | ❌ | ✅ | ✅ |
+| `robodisco/Grow-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_grow.gif) | Grow plants by watering them | ✅ | ✅ | ✅ |
+| `robodisco/Laser-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_laser.gif) | Align lasers and mirrors to hit targets | ❌ | ✅ | ❌ |
+| `robodisco/MagicBin-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_magic_bin.gif) | Sort objects into magic bins that transform them | ❌ | ❌ | ❌ |
+| `robodisco/Switch-v0` | ![](../../docs/envs/assets/random_action_gifs/pybullet_switch.gif) | Toggle switches to open doors and move objects | ❌ | ❌ | ❌ |
 
-The Demos column was verified on 2026-04-14 by running the oracle command
-above on every env. Failing envs typically need additional `CFG`
-overrides or hit known issues (missing NSRTs, sampler-grounding errors,
-or execution drift); they may still be useful as targets for skill or
+The Demos column was verified by running the oracle command above on
+every env. Failing envs typically need additional `CFG` overrides or
+hit known issues (missing NSRTs, sampler-grounding errors, or
+execution drift); they may still be useful as targets for skill or
 NSRT learning research. A handful of envs (`Circuit`, `Cover`, `Laser`,
 `Switch`) also currently fail to instantiate through the Gymnasium
 wrapper with parser defaults — pass `cfg_overrides={...}` to
-`mara_robosim.make(...)` or call `utils.update_config({...})` before
+`robodisco.make(...)` or call `utils.update_config({...})` before
 `make()` to supply the missing fields.
 
 ## Per-environment configuration
 
-The MARA RoboSim envs read from predicators' global `CFG` object, which
+The RoboDisco envs read from predicators' global `CFG` object, which
 normally gets populated by `predicators/main.py`'s command-line parser.
 For library use, set it explicitly:
 
@@ -120,8 +122,8 @@ utils.reset_config({
 You can also pass overrides per-make via the wrapper:
 
 ```python
-env = mara_robosim.make(
-    "mara/Blocks-v0",
+env = robodisco.make(
+    "robodisco/Blocks-v0",
     render_mode="rgb_array",
     cfg_overrides={"blocks_num_blocks_train": [4]},
 )

--- a/predicators/envs/gymnasium_wrapper.py
+++ b/predicators/envs/gymnasium_wrapper.py
@@ -1,15 +1,17 @@
-"""MARA RoboSim: a Gymnasium-API wrapper for predicators' PyBullet envs.
+"""RoboDisco: a Gymnasium-API wrapper for predicators' PyBullet envs.
 
-Exposes the 15 native ``predicators.envs.pybullet_*`` environments through a
-standard ``gymnasium.Env`` interface so the suite can be used as a
-manipulation benchmark independent of the predicators planning framework.
+RoboDisco (Robot Model Discovery Benchmark) exposes the 15 native
+``predicators.envs.pybullet_*`` environments through a standard
+``gymnasium.Env`` interface so the suite can be used as a robot
+model-discovery benchmark independent of the predicators planning
+framework.
 
 Quick start::
 
-    from predicators.envs import gymnasium_wrapper as mara_robosim
+    from predicators.envs import gymnasium_wrapper as robodisco
 
-    mara_robosim.register_all_environments()
-    env = mara_robosim.make("mara/Blocks-v0", render_mode="rgb_array")
+    robodisco.register_all_environments()
+    env = robodisco.make("robodisco/Blocks-v0", render_mode="rgb_array")
     obs, info = env.reset()
     action = env.action_space.sample()
     obs, reward, terminated, truncated, info = env.step(action)
@@ -37,10 +39,10 @@ def _ensure_cfg_initialized() -> None:
     """Make sure predicators' global ``CFG`` has its default fields set.
 
     The planning entry points (``main.py``, tests) initialize ``CFG``
-    via command-line parsing before any env is constructed.  When MARA
-    RoboSim is used as a library, that bootstrap hasn't run, so required
-    fields like ``seed`` are missing and ``BaseEnv.__init__`` would
-    crash.
+    via command-line parsing before any env is constructed.  When
+    RoboDisco is used as a library, that bootstrap hasn't run, so
+    required fields like ``seed`` are missing and ``BaseEnv.__init__``
+    would crash.
     """
     from predicators import utils  # pylint: disable=import-outside-toplevel
     from predicators.settings import \
@@ -60,7 +62,7 @@ def _resolve_cls(
     return env_cls
 
 
-class MARARoboSimEnv(gymnasium.Env):
+class RoboDiscoEnv(gymnasium.Env):
     """Wraps a predicators ``PyBulletEnv`` as a standard ``gymnasium.Env``.
 
     Observation: flattened object features as a ``Box`` space, with
@@ -191,37 +193,40 @@ class MARARoboSimEnv(gymnasium.Env):
 # Environment registry
 # ---------------------------------------------------------------------------
 
-_ENTRY_POINT = "predicators.envs.gymnasium_wrapper:MARARoboSimEnv"
+_ENTRY_POINT = "predicators.envs.gymnasium_wrapper:RoboDiscoEnv"
 
 # (gymnasium env id, predicators env class entry point).
 _ENV_REGISTRY: List[Tuple[str, str]] = [
-    ("mara/Ants-v0", "predicators.envs.pybullet_ants:PyBulletAntsEnv"),
-    ("mara/Balance-v0",
+    ("robodisco/Ants-v0", "predicators.envs.pybullet_ants:PyBulletAntsEnv"),
+    ("robodisco/Balance-v0",
      "predicators.envs.pybullet_balance:PyBulletBalanceEnv"),
-    ("mara/Barrier-v0",
+    ("robodisco/Barrier-v0",
      "predicators.envs.pybullet_barrier:PyBulletBarrierEnv"),
-    ("mara/Blocks-v0", "predicators.envs.pybullet_blocks:PyBulletBlocksEnv"),
-    ("mara/Boil-v0", "predicators.envs.pybullet_boil:PyBulletBoilEnv"),
-    ("mara/Circuit-v0",
+    ("robodisco/Blocks-v0",
+     "predicators.envs.pybullet_blocks:PyBulletBlocksEnv"),
+    ("robodisco/Boil-v0", "predicators.envs.pybullet_boil:PyBulletBoilEnv"),
+    ("robodisco/Circuit-v0",
      "predicators.envs.pybullet_circuit:PyBulletCircuitEnv"),
-    ("mara/Coffee-v0", "predicators.envs.pybullet_coffee:PyBulletCoffeeEnv"),
-    ("mara/Cover-v0", "predicators.envs.pybullet_cover:PyBulletCoverEnv"),
-    ("mara/Domino-v0",
+    ("robodisco/Coffee-v0",
+     "predicators.envs.pybullet_coffee:PyBulletCoffeeEnv"),
+    ("robodisco/Cover-v0", "predicators.envs.pybullet_cover:PyBulletCoverEnv"),
+    ("robodisco/Domino-v0",
      "predicators.envs.pybullet_domino.composed_env:PyBulletDominoEnvNew"),
-    ("mara/Fan-v0", "predicators.envs.pybullet_fan:PyBulletFanEnv"),
-    ("mara/Float-v0", "predicators.envs.pybullet_float:PyBulletFloatEnv"),
-    ("mara/Grow-v0", "predicators.envs.pybullet_grow:PyBulletGrowEnv"),
-    ("mara/Laser-v0", "predicators.envs.pybullet_laser:PyBulletLaserEnv"),
-    ("mara/MagicBin-v0",
+    ("robodisco/Fan-v0", "predicators.envs.pybullet_fan:PyBulletFanEnv"),
+    ("robodisco/Float-v0", "predicators.envs.pybullet_float:PyBulletFloatEnv"),
+    ("robodisco/Grow-v0", "predicators.envs.pybullet_grow:PyBulletGrowEnv"),
+    ("robodisco/Laser-v0", "predicators.envs.pybullet_laser:PyBulletLaserEnv"),
+    ("robodisco/MagicBin-v0",
      "predicators.envs.pybullet_magic_bin:PyBulletMagicBinEnv"),
-    ("mara/Switch-v0", "predicators.envs.pybullet_switch:PyBulletSwitchEnv"),
+    ("robodisco/Switch-v0",
+     "predicators.envs.pybullet_switch:PyBulletSwitchEnv"),
 ]
 
 _REGISTERED = False
 
 
 def register_all_environments() -> None:
-    """Register every MARA RoboSim environment with gymnasium.
+    """Register every RoboDisco environment with gymnasium.
 
     Safe to call multiple times (idempotent).
     """
@@ -238,7 +243,7 @@ def register_all_environments() -> None:
 
 
 def make(env_id: str, **kwargs: Any) -> gymnasium.Env:
-    """Create a MARA RoboSim gymnasium environment by id.
+    """Create a RoboDisco gymnasium environment by id.
 
     Automatically calls :func:`register_all_environments` if not done
     yet.
@@ -248,6 +253,6 @@ def make(env_id: str, **kwargs: Any) -> gymnasium.Env:
 
 
 def get_all_env_ids() -> Set[str]:
-    """Return the set of all registered MARA RoboSim environment ids."""
+    """Return the set of all registered RoboDisco environment ids."""
     register_all_environments()
     return {eid for eid, _ in _ENV_REGISTRY}

--- a/scripts/robodisco_getting_started.py
+++ b/scripts/robodisco_getting_started.py
@@ -1,8 +1,8 @@
-"""Smoke-test that mirrors the MARA RoboSim getting-started notebook.
+"""Smoke-test that mirrors the RoboDisco getting-started notebook.
 
 Run::
 
-    PYTHONHASHSEED=0 python scripts/mara_robosim_getting_started.py
+    PYTHONHASHSEED=0 python scripts/robodisco_getting_started.py
 """
 
 from pathlib import Path
@@ -13,11 +13,10 @@ from numpy.typing import NDArray
 from PIL import Image
 
 from predicators import utils
-from predicators.envs import gymnasium_wrapper as mara_robosim
+from predicators.envs import gymnasium_wrapper as robodisco
 from predicators.structs import State
 
-OUT_DIR = Path(
-    __file__).resolve().parent / "mara_robosim_getting_started_output"
+OUT_DIR = Path(__file__).resolve().parent / "robodisco_getting_started_output"
 OUT_DIR.mkdir(exist_ok=True)
 
 # Apply small task counts so the smoke test runs quickly.
@@ -25,8 +24,8 @@ utils.reset_config({"num_train_tasks": 1, "num_test_tasks": 1})
 
 # ── 1. Discover environments ─────────────────────────────────────────────
 
-mara_robosim.register_all_environments()
-env_ids = sorted(mara_robosim.get_all_env_ids())
+robodisco.register_all_environments()
+env_ids = sorted(robodisco.get_all_env_ids())
 print(f"[1/6] Found {len(env_ids)} environments")
 assert len(env_ids) == 15, f"Expected 15 environments, got {len(env_ids)}"
 for eid in env_ids:
@@ -34,9 +33,9 @@ for eid in env_ids:
 
 # ── 2. Create environment ────────────────────────────────────────────────
 
-env = mara_robosim.make("mara/Blocks-v0", render_mode="rgb_array")
+env = robodisco.make("robodisco/Blocks-v0", render_mode="rgb_array")
 obs, info = env.reset()
-print("\n[2/6] Created mara/Blocks-v0")
+print("\n[2/6] Created robodisco/Blocks-v0")
 assert isinstance(obs, np.ndarray)
 assert obs.shape == env.observation_space.shape
 
@@ -122,7 +121,7 @@ print("\n[7/7] Resetting every registered env (non-fatal report):")
 ok, fail = [], []
 for eid in env_ids:
     try:
-        e = mara_robosim.make(eid)
+        e = robodisco.make(eid)
         e.reset()
         e.close()
         ok.append(eid)

--- a/tests/envs/test_robodisco.py
+++ b/tests/envs/test_robodisco.py
@@ -1,4 +1,4 @@
-"""Tests for the MARA RoboSim gymnasium wrapper and env registration."""
+"""Tests for the RoboDisco gymnasium wrapper and env registration."""
 # pylint: disable=redefined-outer-name
 
 import gymnasium
@@ -6,25 +6,25 @@ import numpy as np
 import pytest
 
 from predicators import utils
-from predicators.envs.gymnasium_wrapper import MARARoboSimEnv, \
-    get_all_env_ids, make, register_all_environments
+from predicators.envs.gymnasium_wrapper import RoboDiscoEnv, get_all_env_ids, \
+    make, register_all_environments
 from predicators.structs import State
 
 
 @pytest.fixture(scope="module")
-def mara_env():
-    """Create a single mara/Blocks-v0 env shared across the module."""
+def robodisco_env():
+    """Create a single robodisco/Blocks-v0 env shared across the module."""
     utils.reset_config({"num_train_tasks": 1, "num_test_tasks": 1})
-    env = make("mara/Blocks-v0")
+    env = make("robodisco/Blocks-v0")
     yield env
     env.close()
 
 
 @pytest.fixture(scope="module")
 def rgb_env():
-    """A mara/Blocks-v0 env with rgb_array rendering enabled."""
+    """A robodisco/Blocks-v0 env with rgb_array rendering enabled."""
     utils.reset_config({"num_train_tasks": 1, "num_test_tasks": 1})
-    env = make("mara/Blocks-v0", render_mode="rgb_array")
+    env = make("robodisco/Blocks-v0", render_mode="rgb_array")
     yield env
     env.close()
 
@@ -37,8 +37,11 @@ def rgb_env():
 def test_register_all_environments_count():
     """register_all_environments() registers all 15 envs."""
     register_all_environments()
-    mara_ids = {eid for eid in gymnasium.registry if eid.startswith("mara/")}
-    assert len(mara_ids) == 15
+    rd_ids = {
+        eid
+        for eid in gymnasium.registry if eid.startswith("robodisco/")
+    }
+    assert len(rd_ids) == 15
 
 
 def test_get_all_env_ids_returns_15():
@@ -47,9 +50,10 @@ def test_get_all_env_ids_returns_15():
 
 
 def test_get_all_env_ids_prefix():
-    """Every id returned by get_all_env_ids() starts with 'mara/'."""
+    """Every id returned by get_all_env_ids() starts with 'robodisco/'."""
     for eid in get_all_env_ids():
-        assert eid.startswith("mara/"), f"{eid} does not start with 'mara/'"
+        assert eid.startswith("robodisco/"), \
+            f"{eid} does not start with 'robodisco/'"
 
 
 def test_register_is_idempotent():
@@ -64,24 +68,24 @@ def test_register_is_idempotent():
 # ---------------------------------------------------------------------------
 
 
-def test_make_creates_env(mara_env):
-    """make('mara/Blocks-v0') creates a working gymnasium env."""
-    assert mara_env is not None
-    assert isinstance(mara_env.unwrapped, MARARoboSimEnv)
+def test_make_creates_env(robodisco_env):
+    """make('robodisco/Blocks-v0') creates a working gymnasium env."""
+    assert robodisco_env is not None
+    assert isinstance(robodisco_env.unwrapped, RoboDiscoEnv)
 
 
-def test_observation_space(mara_env):
+def test_observation_space(robodisco_env):
     """The env has a Box observation space with finite-shaped float32."""
-    obs_space = mara_env.observation_space
+    obs_space = robodisco_env.observation_space
     assert isinstance(obs_space, gymnasium.spaces.Box)
     assert len(obs_space.shape) == 1
     assert obs_space.shape[0] > 0
     assert obs_space.dtype == np.float32
 
 
-def test_action_space(mara_env):
+def test_action_space(robodisco_env):
     """The env has a Box action space."""
-    act_space = mara_env.action_space
+    act_space = robodisco_env.action_space
     assert isinstance(act_space, gymnasium.spaces.Box)
     assert len(act_space.shape) >= 1
     assert act_space.shape[0] > 0
@@ -92,11 +96,11 @@ def test_action_space(mara_env):
 # ---------------------------------------------------------------------------
 
 
-def test_reset_returns_tuple(mara_env):
+def test_reset_returns_tuple(robodisco_env):
     """reset() returns (obs, info) with correct shapes and types."""
-    obs, info = mara_env.reset()
+    obs, info = robodisco_env.reset()
     assert isinstance(obs, np.ndarray)
-    assert obs.shape == mara_env.observation_space.shape
+    assert obs.shape == robodisco_env.observation_space.shape
     assert obs.dtype == np.float32
     assert isinstance(info, dict)
 
@@ -106,14 +110,14 @@ def test_reset_returns_tuple(mara_env):
 # ---------------------------------------------------------------------------
 
 
-def test_step_returns_five_tuple(mara_env):
+def test_step_returns_five_tuple(robodisco_env):
     """step() returns the standard gymnasium 5-tuple."""
-    mara_env.reset()
-    action = mara_env.action_space.sample()
-    obs, reward, terminated, truncated, info = mara_env.step(action)
+    robodisco_env.reset()
+    action = robodisco_env.action_space.sample()
+    obs, reward, terminated, truncated, info = robodisco_env.step(action)
 
     assert isinstance(obs, np.ndarray)
-    assert obs.shape == mara_env.observation_space.shape
+    assert obs.shape == robodisco_env.observation_space.shape
     assert obs.dtype == np.float32
     assert isinstance(reward, float)
     assert isinstance(terminated, bool)
@@ -126,20 +130,20 @@ def test_step_returns_five_tuple(mara_env):
 # ---------------------------------------------------------------------------
 
 
-def test_reset_info_contains_state_and_goal_reached(mara_env):
+def test_reset_info_contains_state_and_goal_reached(robodisco_env):
     """info from reset() contains 'state' and 'goal_reached' keys."""
-    _, info = mara_env.reset()
+    _, info = robodisco_env.reset()
     assert "state" in info
     assert isinstance(info["state"], State)
     assert "goal_reached" in info
     assert isinstance(info["goal_reached"], bool)
 
 
-def test_step_info_contains_state_and_goal_reached(mara_env):
+def test_step_info_contains_state_and_goal_reached(robodisco_env):
     """info from step() also contains 'state' and 'goal_reached' keys."""
-    mara_env.reset()
-    action = mara_env.action_space.sample()
-    _, _, _, _, info = mara_env.step(action)
+    robodisco_env.reset()
+    action = robodisco_env.action_space.sample()
+    _, _, _, _, info = robodisco_env.step(action)
     assert "state" in info
     assert isinstance(info["state"], State)
     assert "goal_reached" in info


### PR DESCRIPTION
## Summary

Rebrand the Gymnasium-API wrapper from **MARA RoboSim** to **RoboDisco** (Robot Model Discovery Benchmark) — a clearer name that matches the suite's positioning as an embodied world-model and causal-discovery benchmark.

### User-facing rename

| Was | Is |
|---|---|
| `MARARoboSimEnv` | `RoboDiscoEnv` |
| `from predicators.envs import gymnasium_wrapper as mara_robosim` | `from predicators.envs import gymnasium_wrapper as robodisco` |
| `mara/Blocks-v0`, `mara/Ants-v0`, … | `robodisco/Blocks-v0`, `robodisco/Ants-v0`, … |
| `predicators.envs.gymnasium_wrapper:MARARoboSimEnv` (entry point) | `predicators.envs.gymnasium_wrapper:RoboDiscoEnv` |
| `scripts/mara_robosim_getting_started.py` | `scripts/robodisco_getting_started.py` |
| `scripts/mara_robosim_getting_started_output/` | `scripts/robodisco_getting_started_output/` |
| `tests/envs/test_mara_robosim.py` | `tests/envs/test_robodisco.py` |

### Module filename

The source file stays `predicators/envs/gymnasium_wrapper.py` — the filename describes the implementation (a Gymnasium wrapper), while the brand is applied at the class, env-ID, and import-alias layer.

### Docs updates

- `README.md` top-level section heading and description → **RoboDisco**.
- `predicators/envs/README.md` — title banner, quick-start code, per-env config snippet, standalone API, walkthrough links, env-ID table rows, and all "MARA RoboSim" prose.
- `notebooks/getting_started.ipynb` — rewritten with the RoboDisco brand and import idiom.
- `predicators/envs/README.md` now links the project page: <https://yichao-liang.github.io/robodisco-site/> (the site repo was also renamed from `mara-robosim-site` to `robodisco-site`).

## Test plan

- [x] `pytest tests/envs/test_robodisco.py -v` — 12 tests pass (registration, spaces, reset/step, info dict, render).
- [x] `PYTHONHASHSEED=0 python scripts/robodisco_getting_started.py` — notebook-parity smoke test passes; 11/15 envs reset cleanly via the wrapper (Circuit / Cover / Laser / Switch still need additional `CFG` overrides, unchanged from before).
- [x] `mypy . --config-file mypy.ini` — clean across 565 source files.
- [x] `pytest predicators/envs/gymnasium_wrapper.py tests/envs/test_robodisco.py scripts/robodisco_getting_started.py --pylint -m pylint --pylint-rcfile=.predicators_pylintrc` — 3 passed.
- [x] `yapf` / `docformatter` / `isort` — clean and idempotent.
- [x] Existing `pybullet_blocks` oracle tests still pass (`23 passed, 8 xfailed, 1 xpassed`).