### PR TITLE
Stop tracking CLAUDE.md and switch to pybullet-arm64

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,0 @@
-# Instructions
-
-- Never add Claude as a co-author on git commits (no `Co-Authored-By` lines)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "pillow==10.3.0",
         "requests",
         "slack_bolt",
-        "pybullet>=3.2.0",
+        "pybullet-arm64>=3.2.8",
         "scikit-learn>=1.1.3",
         "graphlib-backport",
         "openai==1.19.0",


### PR DESCRIPTION
## Summary
- Stop tracking `CLAUDE.md` (already in `.gitignore` but committed before the rule)
- Replace `pybullet>=3.2.0` with `pybullet-arm64>=3.2.8` in `setup.py` for arm64 compatibility

## Test plan
- [ ] `pip install -e .` succeeds on arm64 macOS
- [ ] `CLAUDE.md` no longer appears in `git ls-files`