### PR TITLE
Fix pybullet block tipping freeze; add GUI entry points to blocks and cover

### DIFF
--- a/predicators/envs/pybullet_blocks.py
+++ b/predicators/envs/pybullet_blocks.py
@@ -356,3 +356,22 @@ class PyBulletBlocksEnv(PyBulletEnv, BlocksEnv):
                            lineWidth=5.0,
                            physicsClientId=physics_client_id)
         # Possibly more debug text...
+
+
+if __name__ == "__main__":
+    # Run a simple simulation to test the environment.
+    import time
+
+    CFG.seed = 0
+    CFG.env = "pybullet_blocks"
+    CFG.num_train_tasks = 1
+    env = PyBulletBlocksEnv(use_gui=True)
+    _task = env._generate_train_tasks()[0]  # pylint: disable=protected-access
+    env._set_state(_task.init)  # pylint: disable=protected-access
+
+    while True:
+        # Hold the robot's current joint positions so the arm doesn't swing
+        # toward URDF home and disturb the blocks.
+        _act = Action(np.array(env._pybullet_robot.get_joints()))  # pylint: disable=protected-access
+        env.step(_act)
+        time.sleep(0.01)

--- a/predicators/envs/pybullet_cover.py
+++ b/predicators/envs/pybullet_cover.py
@@ -411,3 +411,22 @@ class PyBulletCoverEnv(PyBulletEnv, CoverEnv):
         hand = (ry - self.y_lb) / (self.y_ub - self.y_lb)
         hand_regions = self._get_hand_regions(self._current_state)
         return any(lb <= hand <= rb for lb, rb in hand_regions)
+
+
+if __name__ == "__main__":
+    # Run a simple simulation to test the environment.
+    import time
+
+    CFG.seed = 0
+    CFG.env = "pybullet_cover"
+    CFG.num_train_tasks = 1
+    env = PyBulletCoverEnv(use_gui=True)
+    _task = env._generate_train_tasks()[0]  # pylint: disable=protected-access
+    env._set_state(_task.init)  # pylint: disable=protected-access
+
+    while True:
+        # Hold the robot's current joint positions so the arm doesn't swing
+        # toward URDF home and disturb the scene.
+        _act = Action(np.array(env._pybullet_robot.get_joints()))  # pylint: disable=protected-access
+        env.step(_act)
+        time.sleep(0.01)

--- a/predicators/envs/pybullet_domino/components/ball_component.py
+++ b/predicators/envs/pybullet_domino/components/ball_component.py
@@ -128,6 +128,9 @@ class BallComponent(DominoEnvComponent):
             radius=self.ball_radius,
             mass=self.ball_mass,
             friction=self.ball_friction,
+            # Match lateral with spinning to preserve the prior behavior
+            # where the ball didn't pinwheel around the contact normal.
+            spinning_friction=self.ball_friction,
             position=(0.75, 1.35, self.table_height + self.ball_height_offset),
             orientation=p.getQuaternionFromEuler([0, 0, 0]),
             physics_client_id=physics_client_id)

--- a/predicators/envs/pybullet_fan.py
+++ b/predicators/envs/pybullet_fan.py
@@ -526,6 +526,10 @@ class PyBulletFanEnv(PyBulletEnv):
             radius=cls.ball_radius,
             mass=cls.ball_mass,
             friction=cls.ball_friction,
+            # Match lateral with spinning so the ball resists rotating around
+            # the contact normal — necessary for it to "stick" where the fan
+            # parks it instead of pinwheeling.
+            spinning_friction=cls.ball_friction,
             position=(0.75, 1.35, cls.table_height + cls.ball_height_offset),
             orientation=p.getQuaternionFromEuler([0, 0, 0]),
             physics_client_id=physics_client_id)

--- a/predicators/pybullet_helpers/objects.py
+++ b/predicators/pybullet_helpers/objects.py
@@ -168,8 +168,19 @@ def create_pybullet_block(
     orientation: Quaternion = (0.0, 0.0, 0.0, 1.0),
     physics_client_id: int = 0,
     add_top_triangle: bool = False,
+    spinning_friction: float = 0.0,
+    rolling_friction: float = 0.0,
 ) -> int:
-    """Create a box-shaped PyBullet body and return its ID."""
+    """Create a box-shaped PyBullet body and return its ID.
+
+    `friction` controls only lateral (sliding) friction.
+    `spinning_friction` and `rolling_friction` default to 0.0
+    (PyBullet's own defaults); set them explicitly only if you actually
+    want to resist rotation around the contact normal or rolling over a
+    contact edge. Setting these equal to `friction` was the prior
+    behavior and caused boxes to freeze in unstable poses (balanced on
+    an edge or corner) on contact.
+    """
     collision_id = p.createCollisionShape(p.GEOM_BOX,
                                           halfExtents=half_extents,
                                           physicsClientId=physics_client_id)
@@ -186,8 +197,8 @@ def create_pybullet_block(
     p.changeDynamics(block_id,
                      linkIndex=-1,
                      lateralFriction=friction,
-                     spinningFriction=friction,
-                     rollingFriction=friction,
+                     spinningFriction=spinning_friction,
+                     rollingFriction=rolling_friction,
                      physicsClientId=physics_client_id)
 
     if add_top_triangle:
@@ -227,7 +238,8 @@ def create_pybullet_block(
         p.changeDynamics(block_id,
                          linkIndex=-1,
                          lateralFriction=friction,
-                         spinningFriction=friction,
+                         spinningFriction=spinning_friction,
+                         rollingFriction=rolling_friction,
                          physicsClientId=physics_client_id)
 
     return block_id
@@ -241,8 +253,16 @@ def create_pybullet_sphere(
     position: Pose3D = (0.0, 0.0, 0.0),
     orientation: Quaternion = (0.0, 0.0, 0.0, 1.0),
     physics_client_id: int = 0,
+    spinning_friction: float = 0.0,
+    rolling_friction: float = 0.0,
 ) -> int:
-    """Create a sphere-shaped PyBullet body and return its ID."""
+    """Create a sphere-shaped PyBullet body and return its ID.
+
+    `friction` controls only lateral (sliding) friction.
+    `spinning_friction` and `rolling_friction` default to 0.0
+    (PyBullet's own defaults); set them explicitly only when you want a
+    sphere to resist spinning or rolling on contact.
+    """
     collision_id = p.createCollisionShape(p.GEOM_SPHERE,
                                           radius=radius,
                                           physicsClientId=physics_client_id)
@@ -259,6 +279,7 @@ def create_pybullet_sphere(
     p.changeDynamics(sphere_id,
                      linkIndex=-1,
                      lateralFriction=friction,
-                     spinningFriction=friction,
+                     spinningFriction=spinning_friction,
+                     rollingFriction=rolling_friction,
                      physicsClientId=physics_client_id)
     return sphere_id


### PR DESCRIPTION
## Summary
- **Bugfix:** boxes created via `create_pybullet_block` froze on an edge or corner instead of settling onto a flat face. The helper was applying the env's `friction` value to `lateralFriction`, `spinningFriction`, *and* `rollingFriction`. With `_obj_friction = 1.2`, the spinning/rolling channels supplied a contact torque equal and opposite to gravity's tipping torque, so cubes never tipped over. The helper now applies `friction` only to lateral; new optional `spinning_friction` and `rolling_friction` kwargs default to `0.0` (PyBullet's own defaults).
- The `pybullet_fan` ball and `pybullet_domino` ball *do* want spinning resistance, so they now pass `spinning_friction=...` explicitly to preserve prior behavior. Static bodies (mass=0) are unaffected because PyBullet ignores friction torques on zero-mass bodies.
- Added `if __name__ == "__main__":` GUI entry points to `pybullet_blocks.py` and `pybullet_cover.py`, the only concrete pybullet envs that didn't already have one. Pattern matches `pybullet_fan.py` / `pybullet_balance.py`.